### PR TITLE
cmd/trayscale: add ability to toggle exit node advertisement

### DIFF
--- a/cmd/trayscale/peerpage.ui
+++ b/cmd/trayscale/peerpage.ui
@@ -16,6 +16,22 @@
               </object>
             </child>
             <child>
+              <object class="AdwPreferencesGroup" id="OptionsGroup">
+                <property name="title">Options</property>
+                <child>
+                  <object class="AdwActionRow" id="AdvertiseExitNodeRow">
+                    <property name="title">Advertise exit node</property>
+                    <child>
+                      <object class="GtkSwitch" id="AdvertiseExitNodeSwitch">
+                        <property name="margin-bottom">12</property>
+                        <property name="margin-top">12</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="AdwPreferencesGroup" id="MiscGroup">
                 <property name="title">Misc.</property>
                 <child>

--- a/cmd/trayscale/trayscale.cmb
+++ b/cmd/trayscale/trayscale.cmb
@@ -38,7 +38,10 @@
 	(2,23,"AdwActionRow","OnlineRow",9,None,None,None,1,None),
 	(2,24,"GtkImage","Online",23,None,None,None,None,None),
 	(2,25,"AdwActionRow","LastHandshakeRow",9,None,None,None,5,None),
-	(2,26,"GtkLabel","LastHandshake",25,None,None,None,None,None)
+	(2,26,"GtkLabel","LastHandshake",25,None,None,None,None,None),
+	(2,27,"AdwPreferencesGroup","OptionsGroup",7,None,None,None,1,None),
+	(2,28,"AdwActionRow","AdvertiseExitNodeRow",27,None,None,None,None,None),
+	(2,29,"GtkSwitch","AdvertiseExitNodeSwitch",28,None,None,None,None,None)
   </object>
   <object_property>
 	(1,1,"AdwApplicationWindow","content","4",None,None,None,None,None),
@@ -72,6 +75,10 @@
 	(2,19,"AdwPreferencesRow","title","Last write",None,None,None,None,None),
 	(2,21,"AdwPreferencesRow","title","Last seen",None,None,None,None,None),
 	(2,23,"AdwPreferencesRow","title","Online",None,None,None,None,None),
-	(2,25,"AdwPreferencesRow","title","Last handshake",None,None,None,None,None)
+	(2,25,"AdwPreferencesRow","title","Last handshake",None,None,None,None,None),
+	(2,27,"AdwPreferencesGroup","title","Options",None,None,None,None,None),
+	(2,28,"AdwPreferencesRow","title","Advertise exit node",None,None,None,None,None),
+	(2,29,"GtkWidget","margin-bottom","12",None,None,None,None,None),
+	(2,29,"GtkWidget","margin-top","12",None,None,None,None,None)
   </object_property>
 </cambalache-project>

--- a/cmd/trayscale/ui.go
+++ b/cmd/trayscale/ui.go
@@ -81,30 +81,36 @@ func NewMainWindow(app *gtk.Application) *MainWindow {
 type PeerPage struct {
 	*adw.StatusPage
 
-	IPGroup          *adw.PreferencesGroup
-	MiscGroup        *adw.PreferencesGroup
-	ExitNodeRow      *adw.ActionRow
-	ExitNodeSwitch   *gtk.Switch
-	OnlineRow        *adw.ActionRow
-	Online           *gtk.Image
-	LastSeenRow      *adw.ActionRow
-	LastSeen         *gtk.Label
-	CreatedRow       *adw.ActionRow
-	Created          *gtk.Label
-	LastWriteRow     *adw.ActionRow
-	LastWrite        *gtk.Label
-	LastHandshakeRow *adw.ActionRow
-	LastHandshake    *gtk.Label
-	RxBytesRow       *adw.ActionRow
-	RxBytes          *gtk.Label
-	TxBytesRow       *adw.ActionRow
-	TxBytes          *gtk.Label
+	IPGroup                 *adw.PreferencesGroup
+	OptionsGroup            *adw.PreferencesGroup
+	AdvertiseExitNodeRow    *adw.ActionRow
+	AdvertiseExitNodeSwitch *gtk.Switch
+	MiscGroup               *adw.PreferencesGroup
+	ExitNodeRow             *adw.ActionRow
+	ExitNodeSwitch          *gtk.Switch
+	OnlineRow               *adw.ActionRow
+	Online                  *gtk.Image
+	LastSeenRow             *adw.ActionRow
+	LastSeen                *gtk.Label
+	CreatedRow              *adw.ActionRow
+	Created                 *gtk.Label
+	LastWriteRow            *adw.ActionRow
+	LastWrite               *gtk.Label
+	LastHandshakeRow        *adw.ActionRow
+	LastHandshake           *gtk.Label
+	RxBytesRow              *adw.ActionRow
+	RxBytes                 *gtk.Label
+	TxBytesRow              *adw.ActionRow
+	TxBytes                 *gtk.Label
 }
 
 func NewPeerPage() *PeerPage {
 	parent0 := adw.NewClamp()
 	parent00 := gtk.NewBox(0, 0)
 	IPGroup := adw.NewPreferencesGroup()
+	OptionsGroup := adw.NewPreferencesGroup()
+	AdvertiseExitNodeRow := adw.NewActionRow()
+	AdvertiseExitNodeSwitch := gtk.NewSwitch()
 	MiscGroup := adw.NewPreferencesGroup()
 	ExitNodeRow := adw.NewActionRow()
 	ExitNodeSwitch := gtk.NewSwitch()
@@ -129,9 +135,19 @@ func NewPeerPage() *PeerPage {
 	parent00.SetObjectProperty("orientation", 1)
 	parent00.SetObjectProperty("spacing", 12)
 	parent00.Append(IPGroup)
+	parent00.Append(OptionsGroup)
 	parent00.Append(MiscGroup)
 
 	IPGroup.SetObjectProperty("title", "Tailscale IPs")
+
+	OptionsGroup.SetObjectProperty("title", "Options")
+	OptionsGroup.Add(AdvertiseExitNodeRow)
+
+	AdvertiseExitNodeRow.SetObjectProperty("title", "Advertise exit node")
+	AdvertiseExitNodeRow.AddSuffix(AdvertiseExitNodeSwitch)
+
+	AdvertiseExitNodeSwitch.SetObjectProperty("margin-bottom", 12)
+	AdvertiseExitNodeSwitch.SetObjectProperty("margin-top", 12)
 
 	MiscGroup.SetObjectProperty("title", "Misc.")
 	MiscGroup.Add(ExitNodeRow)
@@ -176,23 +192,26 @@ func NewPeerPage() *PeerPage {
 	return &PeerPage{
 		StatusPage: parent,
 
-		IPGroup:          IPGroup,
-		MiscGroup:        MiscGroup,
-		ExitNodeRow:      ExitNodeRow,
-		ExitNodeSwitch:   ExitNodeSwitch,
-		OnlineRow:        OnlineRow,
-		Online:           Online,
-		LastSeenRow:      LastSeenRow,
-		LastSeen:         LastSeen,
-		CreatedRow:       CreatedRow,
-		Created:          Created,
-		LastWriteRow:     LastWriteRow,
-		LastWrite:        LastWrite,
-		LastHandshakeRow: LastHandshakeRow,
-		LastHandshake:    LastHandshake,
-		RxBytesRow:       RxBytesRow,
-		RxBytes:          RxBytes,
-		TxBytesRow:       TxBytesRow,
-		TxBytes:          TxBytes,
+		IPGroup:                 IPGroup,
+		OptionsGroup:            OptionsGroup,
+		AdvertiseExitNodeRow:    AdvertiseExitNodeRow,
+		AdvertiseExitNodeSwitch: AdvertiseExitNodeSwitch,
+		MiscGroup:               MiscGroup,
+		ExitNodeRow:             ExitNodeRow,
+		ExitNodeSwitch:          ExitNodeSwitch,
+		OnlineRow:               OnlineRow,
+		Online:                  Online,
+		LastSeenRow:             LastSeenRow,
+		LastSeen:                LastSeen,
+		CreatedRow:              CreatedRow,
+		Created:                 Created,
+		LastWriteRow:            LastWriteRow,
+		LastWrite:               LastWrite,
+		LastHandshakeRow:        LastHandshakeRow,
+		LastHandshake:           LastHandshake,
+		RxBytesRow:              RxBytesRow,
+		RxBytes:                 RxBytes,
+		TxBytesRow:              TxBytesRow,
+		TxBytes:                 TxBytes,
 	}
 }

--- a/internal/xerrors/xerrors.go
+++ b/internal/xerrors/xerrors.go
@@ -1,0 +1,8 @@
+package xerrors
+
+import "errors"
+
+func As[T error](err error) (target T, ok bool) {
+	ok = errors.As(err, &target)
+	return target, ok
+}

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -172,7 +172,7 @@ func (c *Client) AdvertiseExitNode(ctx context.Context, enable bool) error {
 	if err != nil {
 		return fmt.Errorf("get current tailscale options: %w", err)
 	}
-	args = append(append([]string{"up"}, args...), "--advertise-exit-node", strconv.FormatBool(enable))
+	args = append(append([]string{"up"}, args...), "--advertise-exit-node="+strconv.FormatBool(enable))
 
 	_, err = c.run(ctx, args...)
 	return err

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -43,7 +43,7 @@ func (c *Client) run(ctx context.Context, args ...string) (string, error) {
 // network. If the network is not currently connected, it returns
 // nil, nil.
 func (c *Client) Status(ctx context.Context) (*ipnstate.Status, error) {
-	st, err := tailscale.Status(ctx)
+	st, err := localClient.Status(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get tailscale status: %w", err)
 	}

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"deedles.dev/trayscale/internal/xerrors"
@@ -154,11 +155,24 @@ func (c *Client) ExitNode(ctx context.Context, peer *ipnstate.PeerStatus) error 
 		name = peer.TailscaleIPs[0].String()
 	}
 
-	args, err := c.CurrentOptions(ctx)
+	args, err := c.currentOptions(ctx)
 	if err != nil {
 		return fmt.Errorf("get current tailscale options: %w", err)
 	}
 	args = append(append([]string{"up"}, args...), "--exit-node", name) // Thankfully, specifying the same option twice seems to work just fine.
+
+	_, err = c.run(ctx, args...)
+	return err
+}
+
+// AdvertiseExitNode enables and disables exit node advertisement for
+// the current node.
+func (c *Client) AdvertiseExitNode(ctx context.Context, enable bool) error {
+	args, err := c.currentOptions(ctx)
+	if err != nil {
+		return fmt.Errorf("get current tailscale options: %w", err)
+	}
+	args = append(append([]string{"up"}, args...), "--advertise-exit-node", strconv.FormatBool(enable))
 
 	_, err = c.run(ctx, args...)
 	return err

--- a/tailscale/client.go
+++ b/tailscale/client.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"deedles.dev/trayscale/internal/xerrors"
+	"golang.org/x/exp/slices"
 	"tailscale.com/client/tailscale"
 	"tailscale.com/ipn"
 	"tailscale.com/ipn/ipnstate"
@@ -176,4 +177,15 @@ func (c *Client) AdvertiseExitNode(ctx context.Context, enable bool) error {
 
 	_, err = c.run(ctx, args...)
 	return err
+}
+
+// IsExitNodeAdvertised checks if the current node is advertising as
+// an exit node or not.
+func (c *Client) IsExitNodeAdvertised(ctx context.Context) (bool, error) {
+	// TODO: There has got to be a better way to do this...
+	args, err := c.currentOptions(ctx)
+	if err != nil {
+		return false, fmt.Errorf("get current tailscale options: %w", err)
+	}
+	return slices.Contains(args, "--advertise-exit-node"), nil
 }


### PR DESCRIPTION
This started out as a quite different pull request, but as I did some experimentation it wound up also including a bit of a rewrite of `tailscale`. It should be quite a bit more efficient at some stuff now, as well as having a few new features.

Closes #15.
Part of #12 and #13.