### PR TITLE
cmd/gtkbuildergen: add menu support

### DIFF
--- a/cmd/gtkbuildergen/menu.tmpl
+++ b/cmd/gtkbuildergen/menu.tmpl
@@ -1,0 +1,19 @@
+{{- $id := .ID -}}
+
+var {{$id}} = gio.NewMenu()
+
+func init() {
+	{{range $i, $_ := .Sections -}}
+		{{- $sid := printf "s%v" $i -}}
+
+		{{$sid}} := gio.NewMenu()
+		{{range $i, $_ := .Items -}}
+			{{- $iid := printf "%vi%v" $sid $i -}}
+
+			{{$iid}} := gio.NewMenuItem({{.AttrByName "label" | printf "%q"}}, {{.AttrByName "action" | printf "%q"}})
+			{{$sid}}.AppendItem({{$iid}})
+		{{end}}
+
+		{{$id}}.AppendSection("", {{$sid}})
+	{{end -}}
+}

--- a/cmd/gtkbuildergen/output.tmpl
+++ b/cmd/gtkbuildergen/output.tmpl
@@ -12,4 +12,8 @@ import (
 	{{range .Templates -}}
 		{{template "template.tmpl" .}}
 	{{end}}
+
+	{{range .Menus -}}
+		{{template "menu.tmpl" .}}
+	{{end}}
 {{end}}

--- a/cmd/gtkbuildergen/output.tmpl
+++ b/cmd/gtkbuildergen/output.tmpl
@@ -5,15 +5,18 @@ package {{.Package}}
 import (
 	{{range .UI | requires -}}
 		{{.Import | printf "%q"}}
-	{{end}}
+	{{end -}}
+	{{if .UI | hasMenus -}}
+		"github.com/diamondburned/gotk4/pkg/gio/v2"
+	{{end -}}
 )
 
 {{range .UI -}}
 	{{range .Templates -}}
 		{{template "template.tmpl" .}}
-	{{end}}
+	{{end -}}
 
 	{{range .Menus -}}
 		{{template "menu.tmpl" .}}
-	{{end}}
+	{{end -}}
 {{end}}

--- a/cmd/gtkbuildergen/tmpl.go
+++ b/cmd/gtkbuildergen/tmpl.go
@@ -20,6 +20,14 @@ func init() {
 			// TODO: Return better values.
 			return ui[0].Requires
 		},
+		"hasMenus": func(ui []Interface) bool {
+			for _, i := range ui {
+				if len(i.Menus) != 0 {
+					return true
+				}
+			}
+			return false
+		},
 	})
 	tmpl = template.Must(tmpl.ParseFS(tmplFS, "*.tmpl"))
 }

--- a/cmd/gtkbuildergen/uidef.go
+++ b/cmd/gtkbuildergen/uidef.go
@@ -145,6 +145,36 @@ type Menu struct {
 	XMLName xml.Name `xml:"menu"`
 
 	ID string `xml:"id,attr"`
+
+	Sections []Section `xml:"section"`
+}
+
+type Section struct {
+	XMLName xml.Name `xml:"section"`
+
+	Items []Item `xml:"item"`
+}
+
+type Item struct {
+	XMLName xml.Name `xml:"item"`
+
+	Attributes []Attribute `xml:"attribute"`
+}
+
+func (item Item) AttrByName(name string) string {
+	for _, attr := range item.Attributes {
+		if attr.Name == name {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+type Attribute struct {
+	XMLName xml.Name `xml:"attribute"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:",chardata"`
 }
 
 type Class string

--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	_ "embed"
 	"log"
 	"net/netip"
 	"os"
@@ -24,10 +23,7 @@ import (
 	"tailscale.com/types/key"
 )
 
-//go:generate go run deedles.dev/trayscale/cmd/gtkbuildergen -out ui.go mainwindow.ui peerpage.ui
-
-//go:embed menu.ui
-var menuXML string
+//go:generate go run deedles.dev/trayscale/cmd/gtkbuildergen -out ui.go mainwindow.ui peerpage.ui menu.ui
 
 // App is the main type for the app, containing all of the state
 // necessary to run it.
@@ -275,13 +271,10 @@ func (a *App) init(ctx context.Context) {
 		a.statusPage.SetIconName("network-offline-symbolic")
 		a.statusPage.SetDescription("Tailscale is not connected")
 
-		builder := gtk.NewBuilder()
-		builder.AddFromString(menuXML, len(menuXML))
-
 		a.win = NewMainWindow(&a.app.Application)
 
 		// Workaround for Cambalache limitations.
-		a.win.MainMenuButton.SetMenuModel(builder.GetObject("MainMenu").Cast().(gio.MenuModeller))
+		a.win.MainMenuButton.SetMenuModel(MainMenu)
 
 		a.win.StatusSwitch.ConnectStateSet(func(s bool) bool {
 			if s == a.win.StatusSwitch.State() {

--- a/cmd/trayscale/ui.go
+++ b/cmd/trayscale/ui.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 )
 
@@ -227,4 +228,16 @@ func NewPeerPage() *PeerPage {
 		TxBytesRow:              TxBytesRow,
 		TxBytes:                 TxBytes,
 	}
+}
+
+var MainMenu = gio.NewMenu()
+
+func init() {
+	s0 := gio.NewMenu()
+	s0i0 := gio.NewMenuItem("_About", "app.about")
+	s0.AppendItem(s0i0)
+	s0i1 := gio.NewMenuItem("_Quit", "app.quit")
+	s0.AppendItem(s0i1)
+
+	MainMenu.AppendSection("", s0)
 }


### PR DESCRIPTION
This completely eliminates all `GtkBuilder` usage. In so doing, it also fixes a bug that caused the race detector to crash the app. It seems that some usages of `GtkBuilder` were being detected by the race detector, and _only_ by the race detector for some reason, as being violations of the cgo pointer passing rules. I'm not sure if they actually were or not, but this seems to have completely fixed it, so... Problem solved, I guess.