### PR TITLE
cmd/trayscale: make sure that the application is registered before starting the poller

### DIFF
--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -380,6 +380,12 @@ func (a *App) Run(ctx context.Context) {
 
 	a.init(ctx)
 
+	err := a.app.Register(ctx)
+	if err != nil {
+		log.Printf("Error: register application: %v", err)
+		return
+	}
+
 	mk.Chan(&a.poll, 1)
 	go a.poller(ctx)
 


### PR DESCRIPTION
So that's why that warning kept getting printed...