### PR TITLE
internal/empty: add as workaround for `go4.org/unsafe/assume-no-moving-gc`

### DIFF
--- a/cmd/trayscale/rowmanager.go
+++ b/cmd/trayscale/rowmanager.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"deedles.dev/trayscale/internal/xslices"
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"golang.org/x/exp/slices"
@@ -23,6 +24,7 @@ func (m *rowManager[Row, Data]) resize(size int) {
 		for _, r := range m.rows[size:] {
 			m.Parent.Remove(r.Row())
 		}
+		xslices.Clear(m.rows[size:])
 		m.rows = m.rows[:size]
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -43,3 +43,5 @@ require (
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect
 	nhooyr.io/websocket v1.8.7 // indirect
 )
+
+replace go4.org/unsafe/assume-no-moving-gc => ./internal/empty

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	deedles.dev/mk v0.1.0
 	github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20220417101956-dcc3707dc307
 	github.com/diamondburned/gotk4/pkg v0.0.4
-	golang.org/x/exp v0.0.0-20230131013936-aae9b4e6329d
+	golang.org/x/exp v0.0.0-20230202163644-54bba9f4231b
 	tailscale.com v1.36.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,6 @@ go4.org/mem v0.0.0-20220726221520-4f986261bf13 h1:CbZeCBZ0aZj8EfVgnqQcYZgf0lpZ3H
 go4.org/mem v0.0.0-20220726221520-4f986261bf13/go.mod h1:reUoABIJ9ikfM5sgtSF3Wushcza7+WeD01VB9Lirh3g=
 go4.org/netipx v0.0.0-20230125063823-8449b0a6169f h1:ketMxHg+vWm3yccyYiq+uK8D3fRmna2Fcj+awpQp84s=
 go4.org/netipx v0.0.0-20230125063823-8449b0a6169f/go.mod h1:tgPU4N2u9RByaTN3NC2p9xOzyFpte4jYwsIIRF7XlSc=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
-go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
 golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/exp v0.0.0-20230131013936-aae9b4e6329d h1:EdJVZdqCvJN8QvZSbrto8tf354qfT3cfBUPaxdWuOpQ=

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ go4.org/netipx v0.0.0-20230125063823-8449b0a6169f h1:ketMxHg+vWm3yccyYiq+uK8D3fR
 go4.org/netipx v0.0.0-20230125063823-8449b0a6169f/go.mod h1:tgPU4N2u9RByaTN3NC2p9xOzyFpte4jYwsIIRF7XlSc=
 golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
-golang.org/x/exp v0.0.0-20230131013936-aae9b4e6329d h1:EdJVZdqCvJN8QvZSbrto8tf354qfT3cfBUPaxdWuOpQ=
-golang.org/x/exp v0.0.0-20230131013936-aae9b4e6329d/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230202163644-54bba9f4231b h1:EqBVA+nNsObCwQoBEHy4wLU0pi7i8a4AL3pbItPdPkE=
+golang.org/x/exp v0.0.0-20230202163644-54bba9f4231b/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp/typeparams v0.0.0-20220328175248-053ad81199eb h1:fP6C8Xutcp5AlakmT/SkQot0pMicROAsEX7OfNPuG10=
 golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
 golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/internal/empty/empty.go
+++ b/internal/empty/empty.go
@@ -1,0 +1,6 @@
+// Package empty is a completely empty package.
+//
+// This package exists purely as a workaround for
+// go4.org/unsafe/assume-no-moving-gc not being updated very quickly,
+// thus breaking new Go releases.
+package empty

--- a/internal/empty/go.mod
+++ b/internal/empty/go.mod
@@ -1,0 +1,3 @@
+module deedles.dev/trayscale/internal/empty
+
+go 1.20

--- a/internal/xslices/xslices.go
+++ b/internal/xslices/xslices.go
@@ -30,3 +30,13 @@ func Filter[E any, S ~[]E](s S, keep func(E) bool) S {
 	}
 	return s[:to]
 }
+
+// Clear sets every element of s to the zero value of E.
+//
+// TODO: Replace with clear() builtin when Go 1.21 comes out?
+func Clear[E any](s []E) {
+	var z E
+	for i := range s {
+		s[i] = z
+	}
+}


### PR DESCRIPTION
Not sure why someone thinks it's necessary to break every new Go release just on the very slim off-chance that it contains a moving GC, especially when golang/go#46787 exists and they clearly know that stuff would break if that was added, but hey, at least `replace` directives make it relatively easy to get around.