### PR TITLE
cmd/trayscale: set switch activation manually along with state

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo apt-get install -y ${{ env.dependencies }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.dependencies }}
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -34,7 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo apt-get install -y ${{ env.dependencies }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.dependencies }}
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
@@ -51,7 +55,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo apt-get install -y ${{ env.dependencies }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ env.dependencies }}
       - name: Setup Go
         uses: actions/setup-go@v4
         with:

--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -116,7 +116,9 @@ func (a *App) updatePeerPage(page *peerPage, peer *ipnstate.PeerStatus, prefs *i
 	page.container.OptionsGroup.SetVisible(page.self)
 	if page.self {
 		page.container.AdvertiseExitNodeSwitch.SetState(prefs.AdvertisesExitNode())
+		page.container.AdvertiseExitNodeSwitch.SetActive(prefs.AdvertisesExitNode())
 		page.container.AllowLANAccessSwitch.SetState(prefs.ExitNodeAllowLANAccess)
+		page.container.AllowLANAccessSwitch.SetActive(prefs.ExitNodeAllowLANAccess)
 	}
 
 	page.container.AdvertiseRouteButton.SetVisible(page.self)
@@ -146,6 +148,7 @@ func (a *App) updatePeerPage(page *peerPage, peer *ipnstate.PeerStatus, prefs *i
 	page.container.MiscGroup.SetVisible(!page.self)
 	page.container.ExitNodeRow.SetVisible(peer.ExitNodeOption)
 	page.container.ExitNodeSwitch.SetState(peer.ExitNode)
+	page.container.ExitNodeSwitch.SetActive(peer.ExitNode)
 	page.container.RxBytes.SetText(strconv.FormatInt(peer.RxBytes, 10))
 	page.container.TxBytes.SetText(strconv.FormatInt(peer.TxBytes, 10))
 	page.container.Created.SetText(formatTime(peer.Created))
@@ -238,6 +241,7 @@ func (a *App) update(status *ipnstate.Status, prefs *ipn.Prefs) {
 	}
 
 	a.win.StatusSwitch.SetState(online)
+	a.win.StatusSwitch.SetActive(online)
 	a.updatePeers(status, prefs)
 }
 

--- a/dev.deedles.Trayscale.metainfo.xml
+++ b/dev.deedles.Trayscale.metainfo.xml
@@ -41,6 +41,14 @@
 	<content_rating type="oars-1.1" />
 
 	<releases>
+		<release version="v0.8.5" date="2023-03-28">
+			<description>
+				<ul>
+					<li>Fix switch state management for newer versions of Gtk4.</li>
+					<li>Update GNOME runtime to version 44.</li>
+				</ul>
+			</description>
+		</release>
 		<release version="v0.8.4" date="2023-03-27">
 			<description>
 				<ul>


### PR DESCRIPTION
The behavior of this seems to have changed recently. It's possible that the previous behavior was actually a bug. Either way, this seems to work correctly now.