### PR TITLE
cmd/trayscale: migrate from manual polling to `IPNBusWatcher` API

### DIFF
--- a/cmd/trayscale/trayscale.go
+++ b/cmd/trayscale/trayscale.go
@@ -11,7 +11,7 @@ import (
 
 	"deedles.dev/trayscale"
 	"deedles.dev/trayscale/internal/tsutil"
-	"tailscale.com/ipn/ipnstate"
+	"tailscale.com/tailcfg"
 	"tailscale.com/types/opt"
 )
 
@@ -69,9 +69,13 @@ func readAssetString(file string) string {
 	return str.String()
 }
 
-func peerName(status tsutil.Status, peer *ipnstate.PeerStatus, self bool) string {
+func peerName(status tsutil.Status, peer *tailcfg.Node, self bool) string {
+	if peer.ComputedName == "" {
+		peer.InitDisplayNames("")
+	}
+
 	const maxNameLength = 30
-	name := tsutil.DNSOrQuoteHostname(status.Status, peer)
+	name := peer.DisplayName(true)
 	if len(name) > maxNameLength {
 		name = name[:maxNameLength-3] + "..."
 	}
@@ -88,7 +92,7 @@ func peerName(status tsutil.Status, peer *ipnstate.PeerStatus, self bool) string
 	return name
 }
 
-func peerIcon(peer *ipnstate.PeerStatus) string {
+func peerIcon(peer *tailcfg.Node) string {
 	if peer.ExitNode {
 		return "network-workgroup-symbolic"
 	}

--- a/internal/tsutil/client.go
+++ b/internal/tsutil/client.go
@@ -51,6 +51,11 @@ func (c *Client) run(ctx context.Context, args ...string) (string, error) {
 	return out.String(), err
 }
 
+// Watch returns an IPNBusWatcher to get notifications from the Tailscale daemon.
+func (c *Client) Watch(ctx context.Context) (*tailscale.IPNBusWatcher, error) {
+	return localClient.WatchIPNBus(ctx, ipn.NotifyInitialState|ipn.NotifyInitialPrefs)
+}
+
 // Status returns the status of the connection to the Tailscale
 // network. If the network is not currently connected, it returns
 // nil, nil.
@@ -81,7 +86,7 @@ func (c *Client) Stop(ctx context.Context) error {
 
 // ExitNode uses the specified peer as an exit node, or unsets
 // an existing exit node if peer is nil.
-func (c *Client) ExitNode(ctx context.Context, peer *ipnstate.PeerStatus) error {
+func (c *Client) ExitNode(ctx context.Context, peer *tailcfg.Node) error {
 	if peer == nil {
 		var prefs ipn.Prefs
 		prefs.ClearExitNode()
@@ -102,7 +107,7 @@ func (c *Client) ExitNode(ctx context.Context, peer *ipnstate.PeerStatus) error 
 	}
 
 	var prefs ipn.Prefs
-	prefs.SetExitNodeIP(peer.TailscaleIPs[0].String(), status)
+	prefs.SetExitNodeIP(peer.Addresses[0].String(), status)
 	_, err = localClient.EditPrefs(ctx, &ipn.MaskedPrefs{
 		Prefs:         prefs,
 		ExitNodeIDSet: true,


### PR DESCRIPTION
This might not work as intended, unfortunately, but if it _does_ work it should be both cleaner and more efficient. Currently, the biggest issue seems to be that the `ipn.Notify` does not provide any obvious way to get information about, for example, which node is currently selected as an exit node.