### PR TITLE
cmd/trayscale: add abstraction to manage tray

### DIFF
--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -394,13 +394,13 @@ func (a *App) initTray(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-a.tray.NotfiyShow():
+		case <-a.tray.ShowChan():
 			glib.IdleAdd(func() {
 				if a.app != nil {
 					a.app.Activate()
 				}
 			})
-		case <-a.tray.NotfiyQuit():
+		case <-a.tray.QuitChan():
 			a.Quit()
 		}
 	}

--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -221,7 +221,7 @@ func (a *App) update(s tsutil.Status) {
 	if a.online != online {
 		a.online = online
 		a.notify(online) // TODO: Notify on startup if not connected?
-		a.tray.SetIcon(online)
+		a.tray.SetOnlineStatus(online)
 	}
 	if a.win == nil {
 		return

--- a/cmd/trayscale/systray.go
+++ b/cmd/trayscale/systray.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "embed"
+
 	"fyne.io/systray"
 )
 
@@ -37,6 +39,21 @@ func (t *tray) SetOnlineStatus(online bool) {
 	}
 
 	systray.SetIcon(statusIcon(online))
+}
+
+var (
+	//go:embed status-icon-active.png
+	statusIconActive []byte
+
+	//go:embed status-icon-inactive.png
+	statusIconInactive []byte
+)
+
+func statusIcon(online bool) []byte {
+	if online {
+		return statusIconActive
+	}
+	return statusIconInactive
 }
 
 var systrayExit = make(chan func(), 1)

--- a/cmd/trayscale/systray.go
+++ b/cmd/trayscale/systray.go
@@ -1,6 +1,43 @@
 package main
 
-import "fyne.io/systray"
+import (
+	"fyne.io/systray"
+)
+
+type tray struct {
+	showItem *systray.MenuItem
+	quitItem *systray.MenuItem
+}
+
+func initTray(online bool) *tray {
+	systray.SetIcon(statusIcon(online))
+	systray.SetTitle("Trayscale")
+
+	showWindow := systray.AddMenuItem("Show", "")
+	systray.AddSeparator()
+	quit := systray.AddMenuItem("Quit", "")
+
+	return &tray{
+		showItem: showWindow,
+		quitItem: quit,
+	}
+}
+
+func (t *tray) NotfiyQuit() <-chan struct{} {
+	return t.quitItem.ClickedCh
+}
+
+func (t *tray) NotfiyShow() <-chan struct{} {
+	return t.showItem.ClickedCh
+}
+
+func (t *tray) SetIcon(online bool) {
+	if t == nil {
+		return
+	}
+
+	systray.SetIcon(statusIcon(online))
+}
 
 var systrayExit = make(chan func(), 1)
 

--- a/cmd/trayscale/systray.go
+++ b/cmd/trayscale/systray.go
@@ -31,7 +31,7 @@ func (t *tray) NotfiyShow() <-chan struct{} {
 	return t.showItem.ClickedCh
 }
 
-func (t *tray) SetIcon(online bool) {
+func (t *tray) SetOnlineStatus(online bool) {
 	if t == nil {
 		return
 	}

--- a/cmd/trayscale/systray.go
+++ b/cmd/trayscale/systray.go
@@ -25,11 +25,11 @@ func initTray(online bool) *tray {
 	}
 }
 
-func (t *tray) NotfiyQuit() <-chan struct{} {
+func (t *tray) QuitChan() <-chan struct{} {
 	return t.quitItem.ClickedCh
 }
 
-func (t *tray) NotfiyShow() <-chan struct{} {
+func (t *tray) ShowChan() <-chan struct{} {
 	return t.showItem.ClickedCh
 }
 

--- a/cmd/trayscale/trayscale.go
+++ b/cmd/trayscale/trayscale.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	_ "embed"
 	"io"
 	"os"
 	"os/signal"
@@ -19,21 +18,6 @@ const (
 	appID                 = "dev.deedles.Trayscale"
 	prefShowWindowAtStart = "showWindowAtStart"
 )
-
-var (
-	//go:embed status-icon-active.png
-	statusIconActive []byte
-
-	//go:embed status-icon-inactive.png
-	statusIconInactive []byte
-)
-
-func statusIcon(online bool) []byte {
-	if online {
-		return statusIconActive
-	}
-	return statusIconInactive
-}
 
 type enum[T any] struct {
 	Index int


### PR DESCRIPTION
This is a follow up/prequel to #68. It aims at grouping all tray actions into
a single place and finding a way to make tray communicate with the app
and vice versa.

Currently it only shows how interactions in tray are used to impact the
entire app (or window). But if the tray will ever support showing live
data (e.g. IPs, exit node status, connection status), it will either need to:
* support receiving data from app
or
* support subscribing to Tailscale updates and deciding what to do separately

What's not yet clear to me right now, is how the tray should handle some actions.
E.g. if there's a toggle to connect/disconnect in tray it can either use the toggle
path from app or interact with Tailscale directly and hope that the app/window
gets updated off its own status subscription. 