### PR TITLE
cmd/trayscale: avoid mutlpiple tray init

### DIFF
--- a/cmd/trayscale/app.go
+++ b/cmd/trayscale/app.go
@@ -388,7 +388,9 @@ func (a *App) onAppActivate(ctx context.Context) {
 }
 
 func (a *App) initTray(ctx context.Context) {
-	a.tray = initTray(a.online)
+	if a.tray == nil {
+		a.tray = initTray(a.online)
+	}
 
 	for {
 		select {


### PR DESCRIPTION
This makes the call to `initTray` only once and avoids adding the same set of menu items to the tray.

Such issue can happen when the user toggles tray off and on at least once in a single run of Trayscale.

![image](https://github.com/DeedleFake/trayscale/assets/11974489/6dc38c9d-d99c-49bc-a6f9-24f0a5af814f)
