### PR TITLE
internal/ui: use `deedles.dev/state` to simplify data flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	deedles.dev/state v0.1.3 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
 	github.com/BurntSushi/toml v1.3.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 deedles.dev/mk v0.1.0 h1:xrvuJA3+R/j6/6AZPc+o31I1rotdKLrAYJxhZJwdOuc=
 deedles.dev/mk v0.1.0/go.mod h1:TSFsz0T+BvhNqJae0yrj+KadkN4elx248PCpq2Ol4ME=
+deedles.dev/state v0.1.3 h1:ZvNlVuXRBeOXELaSRyctFxkeFZ91cey3rf3z3Yt7fsA=
+deedles.dev/state v0.1.3/go.mod h1:Dt1w9EV2ADMCrOsg8mj/kLfnMxL1DBKM3SYSfnS8xtw=
 filippo.io/edwards25519 v1.0.0 h1:0wAIcmJUqRdI8IJ/3eGi5/HwXZWPujYXXlkrQogz0Ek=
 filippo.io/edwards25519 v1.0.0/go.mod h1:N1IkdkCkiLB6tki+MYJoSx2JTY9NUlxZE7eHn5EwJns=
 filippo.io/mkcert v1.4.4 h1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=


### PR DESCRIPTION
This is tad experimental, but just changing a small piece of code to it is already fairly promising.

Closes #19.