### PR TITLE
Improve the metadata of the desktop file

### DIFF
--- a/dev.deedles.Trayscale.desktop
+++ b/dev.deedles.Trayscale.desktop
@@ -3,8 +3,10 @@ Version=1.0
 Type=Application
 
 Name=Trayscale
+GenericName=Tailscale Client
 Comment=An unofficial GUI interface for the Tailscale daemon.
 Categories=System;GNOME;GTK;
+Keywords=tailscale;vpn;
 
 Icon=dev.deedles.Trayscale
 Exec=trayscale

--- a/dev.deedles.Trayscale.desktop
+++ b/dev.deedles.Trayscale.desktop
@@ -3,7 +3,7 @@ Version=1.0
 Type=Application
 
 Name=Trayscale
-Comment=An unofficial GUI wrapper around the Tailscale CLI.
+Comment=An unofficial GUI interface for the Tailscale daemon.
 Categories=System;GNOME;GTK;
 
 Icon=dev.deedles.Trayscale


### PR DESCRIPTION
This does two things:
- Fix description still mentioning it being a cli wrapper.
- Adds more desktop file metadata to make it a bit easier to find the app. You can for example search for "tailscale" or "vpn" now.