### PR TITLE
internal/ui: clean up some iterator stuff

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"iter"
 	"log/slog"
 	"os"
 	"slices"
@@ -11,7 +10,6 @@ import (
 	"deedles.dev/mk"
 	"deedles.dev/trayscale/internal/tray"
 	"deedles.dev/trayscale/internal/tsutil"
-	"deedles.dev/xiter"
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gdk/v4"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
@@ -129,11 +127,19 @@ func (a *App) updatePeers(status tsutil.Status) {
 	}
 
 	peerMap := status.Status.Peer
-	peers := slices.SortedFunc(iter.Seq[key.NodePublic](xiter.Filter(xiter.MapKeys(status.Status.Peer),
-		func(peer key.NodePublic) bool {
-			return !tsutil.IsMullvad(peerMap[peer])
-		})),
-		key.NodePublic.Compare)
+	peersseq := func(yield func(key.NodePublic) bool) {
+		for k, p := range status.Status.Peer {
+			if tsutil.IsMullvad(p) {
+				continue
+			}
+			if !yield(k) {
+				return
+			}
+		}
+	}
+	peers := make([]key.NodePublic, 0, len(status.Status.Peer))
+	peers = slices.AppendSeq(peers, peersseq)
+	slices.SortFunc(peers, key.NodePublic.Compare)
 
 	for key, page := range a.peerPages {
 		if _, ok := peerMap[key]; !ok {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -127,18 +127,13 @@ func (a *App) updatePeers(status tsutil.Status) {
 	}
 
 	peerMap := status.Status.Peer
-	peersseq := func(yield func(key.NodePublic) bool) {
-		for k, p := range status.Status.Peer {
-			if tsutil.IsMullvad(p) {
-				continue
-			}
-			if !yield(k) {
-				return
-			}
-		}
-	}
 	peers := make([]key.NodePublic, 0, len(status.Status.Peer))
-	peers = slices.AppendSeq(peers, peersseq)
+	for k, p := range peerMap {
+		if tsutil.IsMullvad(p) {
+			continue
+		}
+		peers = append(peers, k)
+	}
 	slices.SortFunc(peers, key.NodePublic.Compare)
 
 	for key, page := range a.peerPages {

--- a/internal/ui/rowmanager.go
+++ b/internal/ui/rowmanager.go
@@ -1,8 +1,10 @@
 package ui
 
 import (
+	"iter"
 	"slices"
 
+	"deedles.dev/xiter"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 )
 
@@ -31,9 +33,14 @@ func (m *rowManager[Data]) resize(size int) {
 }
 
 func (m *rowManager[Data]) Update(data []Data) {
-	m.resize(len(data))
+	m.UpdateFromSeq(slices.Values(data), len(data))
+}
 
-	for i, d := range data {
+func (m *rowManager[Data]) UpdateFromSeq(data iter.Seq[Data], size int) {
+	m.resize(size)
+
+	edata := xiter.Enumerate(xiter.Seq[Data](data))
+	for i, d := range edata {
 		if i < len(m.rows) {
 			m.rows[i].Update(d)
 			continue

--- a/internal/ui/selfpage.go
+++ b/internal/ui/selfpage.go
@@ -383,19 +383,39 @@ func (page *SelfPage) Update(a *App, peer *ipnstate.PeerStatus, status tsutil.St
 	page.fileRows.Update(status.Files)
 	page.FilesGroup.SetVisible(len(status.Files) > 0)
 
-	page.routes = slices.SortedFunc(iter.Seq[netip.Prefix](xiter.Filter(xiter.OfSlice(status.Prefs.AdvertiseRoutes),
-		func(p netip.Prefix) bool { return p.Bits() != 0 })), // Filter
-		func(p1, p2 netip.Prefix) int { // SortedFunc
-			return cmp.Or(p1.Addr().Compare(p2.Addr()), p1.Bits()-p2.Bits())
-		})
-	if len(page.routes) == 0 {
-		page.routes = append(page.routes, netip.Prefix{})
+	routes := func(yield func(netip.Prefix) bool) {
+		for _, r := range status.Prefs.AdvertiseRoutes {
+			if r.Bits() == 0 {
+				continue
+			}
+			if !yield(r) {
+				return
+			}
+		}
 	}
-	eroutes := make([]enum[netip.Prefix], 0, len(page.routes))
-	for i, r := range page.routes {
-		eroutes = append(eroutes, enumerate(i, r))
+	routes = xiter.Or(
+		routes,
+		xiter.Of(netip.Prefix{}),
+	)
+
+	clear(page.routes)
+	page.routes = page.routes[:0]
+	page.routes = slices.AppendSeq(page.routes, routes)
+	slices.SortFunc(page.routes, func(p1, p2 netip.Prefix) int {
+		return cmp.Or(
+			p1.Addr().Compare(p2.Addr()),
+			cmp.Compare(p1.Bits(), p2.Bits()),
+		)
+	})
+
+	eroutes := func(yield func(enum[netip.Prefix]) bool) {
+		for i, r := range page.routes {
+			if !yield(enumerate(i, r)) {
+				return
+			}
+		}
 	}
-	page.routeRows.Update(eroutes)
+	page.routeRows.UpdateFromSeq(eroutes, len(page.routes))
 }
 
 type addrRow struct {


### PR DESCRIPTION
Maybe just using manual `for` loops inside of an iterator function is better in most cases than trying to use `map`/`filter`/etc.