### PR TITLE
macos support

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -51,8 +51,21 @@ _install_macos() {
 	fi
 	
 	echo "Installing for macOS"
-	install -d "$HOMEBREW_PREFIX/bin"
-	install trayscale "$HOMEBREW_PREFIX/bin/"
+	# Create wrapper script to set up environment
+	cat > trayscale.wrapper << EOF
+#!/bin/bash
+export XDG_DATA_DIRS="$HOMEBREW_PREFIX/share:\${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+exec "$HOMEBREW_PREFIX/libexec/trayscale"
+EOF
+	chmod +x trayscale.wrapper
+	
+	# Install binary to libexec (actual executable)
+	install -d "$HOMEBREW_PREFIX/libexec"
+	install trayscale "$HOMEBREW_PREFIX/libexec/"
+	
+	# Install wrapper to bin (what users will run)
+	install trayscale.wrapper "$HOMEBREW_PREFIX/bin/trayscale"
+	rm trayscale.wrapper
 	
 	schema_dir="$HOMEBREW_PREFIX/share/glib-2.0/schemas"
 	install -d "$schema_dir"
@@ -77,6 +90,7 @@ _uninstall_macos() {
 
 	echo "Uninstalling from macOS"
 	rm -f "$HOMEBREW_PREFIX/bin/trayscale"
+	rm -f "$HOMEBREW_PREFIX/libexec/trayscale"
 	
 	schema_dir="$HOMEBREW_PREFIX/share/glib-2.0/schemas"
 	rm -f "$schema_dir/dev.deedles.Trayscale.gschema.xml"

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -91,7 +91,13 @@ func (t *Tray) Update(s tsutil.Status) {
 var systrayExit = make(chan func(), 1)
 
 func Start(onStart func()) {
-	start, stop := systray.RunWithExternalLoop(onStart, nil)
+	start, stop := systray.RunWithExternalLoop(func() {
+		systray.SetIcon(statusIcon(tsutil.Status{}))
+		systray.SetTitle("Trayscale")
+		if onStart != nil {
+			onStart()
+		}
+	}, nil)
 	select {
 	case f := <-systrayExit:
 		f()

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -12,6 +12,7 @@ import (
 	"deedles.dev/trayscale/internal/version"
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
 	"github.com/diamondburned/gotk4/pkg/gio/v2"
+	"github.com/diamondburned/gotk4/pkg/glib/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"tailscale.com/ipn"
 )
@@ -27,7 +28,9 @@ func (a *App) initSettings(ctx context.Context) {
 		switch key {
 		case "tray-icon":
 			if a.settings.Boolean("tray-icon") {
-				go tray.Start(func() { a.initTray(ctx) })
+				glib.IdleAdd(func() {
+					tray.Start(func() { a.initTray(ctx) })
+				})
 				return
 			}
 			tray.Stop()
@@ -39,7 +42,9 @@ func (a *App) initSettings(ctx context.Context) {
 
 init:
 	if (a.settings == nil) || a.settings.Boolean("tray-icon") {
-		go tray.Start(func() { a.initTray(ctx) })
+		glib.IdleAdd(func() {
+			tray.Start(func() { a.initTray(ctx) })
+		})
 	}
 }
 


### PR DESCRIPTION
I have tested it on Sequoia 15.3.1 with apple silicon.
I can see the tray icon and main ui

![CleanShot 2025-02-13 at 20 08 09@2x](https://github.com/user-attachments/assets/bd026772-2402-4857-90f9-ea62e6242fe6)
![CleanShot 2025-02-13 at 20 08 21@2x](https://github.com/user-attachments/assets/9aae9da1-3082-439f-9b5d-de7d5c556183)
However font rending is not prefect.

This makes trayscale useful with tailscale cli from homebrew that doesn't come with a gui from `brew install tailscale`
To install build dependencies: `brew install libadwaita gtk4 gobject-introspection`

I also modified the dist.sh script for macos

