### PR TITLE
ignore the compiled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gschemas.compiled
+/trayscale


### PR DESCRIPTION
Updated: It is common practice to add compiled binaries to .gitignore
```
git status                                                                                                                                          11:46:51 AM
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	trayscale

nothing added to commit but untracked files present (use "git add" to track)
```