### PR TITLE
meta: fix incorrect package name in build script

### DIFF
--- a/dist.sh
+++ b/dist.sh
@@ -27,7 +27,7 @@ _build() {
 	fi
 
 	echo "Building $version"
-	go build -v -trimpath -ldflags="-w -s -X 'deedles.dev/trayscale/internal/version.version=$version'" -o trayscale ./cmd/trayscale
+	go build -v -trimpath -ldflags="-w -s -X 'deedles.dev/trayscale/internal/metadata.version=$version'" -o trayscale ./cmd/trayscale
 }
 
 _install() {


### PR DESCRIPTION
Huh. I'm kind of surprised that that didn't cause a build failure or something. Strange.