### PR TITLE
fix: read tray-icon setting inside idle callback to prevent bounce

### DIFF
--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -29,15 +29,13 @@ func (a *App) initSettings(ctx context.Context) {
 	a.settings.ConnectChanged(func(key string) {
 		switch key {
 		case "tray-icon":
-			if a.settings.Boolean("tray-icon") {
-				glib.IdleAdd(func() {
-					a.initTray(ctx)
-				})
-				return
-			}
 			glib.IdleAdd(func() {
-				a.tray.Close()
-				a.tray = nil
+				if a.settings.Boolean("tray-icon") {
+					a.initTray(ctx)
+				} else if a.tray != nil {
+					a.tray.Close()
+					a.tray = nil
+				}
 			})
 
 		case "polling-interval":


### PR DESCRIPTION
### Problem

Toggling "Use Tray Icon" in trayscale's preferences causes the tray icon to appear briefly (~0.5 seconds) then disappear. The icon registers with `StatusNotifierWatcher` via D-Bus but is immediately unregistered, making the preference toggle effectively broken.

### Root Cause

The `showPreferences()` function uses `gio.SettingsBindDefault`, which creates a **bidirectional binding** between the GSettings key and the `AdwSwitchRow` widget. When the preferences dialog opens, the widget initializes to its default value (`false`), then the binding syncs the stored GSettings value (`true`) to the widget. This causes the setting to **bounce**: `true` -> `false` -> `true`.

The old `ConnectChanged` handler read `a.settings.Boolean("tray-icon")` at **signal time** and scheduled different `glib.IdleAdd` callbacks based on that value. Because all `ConnectChanged` signals fire before any idle callbacks execute, the stale `false` signal queued a callback that destroyed the tray, even though the final settled value was `true`.

Confirmed via `gsettings monitor`:
```
tray-icon: true      # bounce starts
tray-icon: false     # widget default overwrites
tray-icon: true      #  binding syncs back
```

### Fix

Move the `Boolean("tray-icon")` check **inside** the `glib.IdleAdd` callback so it reads the current (settled) value at execution time rather than the potentially stale value at signal time. Also adds a nil guard on `a.tray` before calling `Close()`.

### Testing

Built a patched binary and ran it inside the GNOME Platform 49 Flatpak runtime against a live Tailscale daemon. The tray icon remained stable after toggling the preference, and `dbus-monitor` confirmed no unexpected unregister calls. The icon persisted until the user explicitly quit the application.
