### PR TITLE
internal/tray: add profile switching submenu to tray menu

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,3 +106,5 @@ require (
 )
 
 tool honnef.co/go/tools/cmd/staticcheck
+
+replace deedles.dev/tray => github.com/alex-poor/tray v0.1.11-0.20260407004037-2451d98fc544

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@
 9fans.net/go v0.0.8-0.20250307142834-96bdba94b63f/go.mod h1:hHyrZRryGqVdqrknjq5OWDLGCTJ2NeEvtrpR96mjraM=
 deedles.dev/mk v0.1.0 h1:xrvuJA3+R/j6/6AZPc+o31I1rotdKLrAYJxhZJwdOuc=
 deedles.dev/mk v0.1.0/go.mod h1:TSFsz0T+BvhNqJae0yrj+KadkN4elx248PCpq2Ol4ME=
-deedles.dev/tray v0.1.11-0.20251126205835-30c3ecc68b10 h1:UGvQ/yXKOutxqV7cZrPgdqqs/mjSA8OPR0PL15qmnuQ=
-deedles.dev/tray v0.1.11-0.20251126205835-30c3ecc68b10/go.mod h1:Lfd/jNMT3QUxxQ23qt/JYM1bDAqwPIj+A0dWX/qtw+Q=
 deedles.dev/xiter v0.2.1 h1:yyyfo1sDwARp5lyMvILBJpEI28sIFN0TNYagAdBUa+s=
 deedles.dev/xiter v0.2.1/go.mod h1:59997UHUsKAy/8bHUClTfeXdyuLZ6z/+yF++vIpxfx8=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
@@ -20,6 +18,8 @@ github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9 h1:1ltq
 github.com/Kodeworks/golang-image-ico v0.0.0-20141118225523-73f0f4cfade9/go.mod h1:7uhhqiBaR4CpN0k9rMjOtjpcfGd6DG2m04zQxKnWQ0I=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=
 github.com/akutz/memconn v0.1.0/go.mod h1:Jo8rI7m0NieZyLI5e2CDlRdRqRRB4S7Xp77ukDjH+Fw=
+github.com/alex-poor/tray v0.1.11-0.20260407004037-2451d98fc544 h1:C08lmoOuP+D33/PA2mFs4q+fw3593TPVlvWiR9dsrjA=
+github.com/alex-poor/tray v0.1.11-0.20260407004037-2451d98fc544/go.mod h1:T6LSCKPLN2Y+PfawRiZOq3awibqxBm4RCmYrDQgMf04=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -10,7 +10,9 @@ import (
 	"unique"
 
 	"deedles.dev/tray"
+	"deedles.dev/trayscale/internal/metadata"
 	"deedles.dev/trayscale/internal/tsutil"
+	"tailscale.com/ipn"
 )
 
 var (
@@ -48,11 +50,12 @@ func handler(f func()) tray.MenuItemProp {
 }
 
 type Tray struct {
-	OnShow       func()
-	OnConnToggle func()
-	OnExitToggle func()
-	OnSelfNode   func()
-	OnQuit       func()
+	OnShow          func()
+	OnConnToggle    func()
+	OnExitToggle    func()
+	OnSelfNode      func()
+	OnProfileSwitch func(ipn.ProfileID)
+	OnQuit          func()
 
 	m    sync.Mutex
 	item *tray.Item
@@ -62,10 +65,12 @@ type Tray struct {
 	connToggleItem *tray.MenuItem
 	exitToggleItem *tray.MenuItem
 	selfNodeItem   *tray.MenuItem
+	profileItems   map[ipn.ProfileID]*tray.MenuItem
+	profileNames   map[ipn.ProfileID]string
 	quitItem       *tray.MenuItem
 }
 
-func (t *Tray) Start(status *tsutil.IPNStatus) error {
+func (t *Tray) Start(status *tsutil.IPNStatus, profiles *tsutil.ProfileStatus) error {
 	if t.item != nil {
 		return nil
 	}
@@ -88,6 +93,38 @@ func (t *Tray) Start(status *tsutil.IPNStatus) error {
 	t.prev = make(map[unique.Handle[string]][]any)
 
 	menu := item.Menu()
+
+	// The "Switch account" submenu must be the first item added to the
+	// menu. There appears to be a quirk in dbusmenu (or some desktop
+	// environment implementations) where children of a submenu added
+	// via MenuItem.AddChild only render correctly when the submenu has
+	// no preceding siblings at the time it is created.
+	t.profileItems = make(map[ipn.ProfileID]*tray.MenuItem)
+	t.profileNames = make(map[ipn.ProfileID]string)
+	if profiles != nil && len(profiles.Profiles) > 1 {
+		submenu, _ := menu.AddChild(tray.MenuItemLabel("Switch account"))
+		for _, profile := range profiles.Profiles {
+			id := profile.ID
+			name := profileName(profile)
+			t.profileNames[id] = name
+
+			label := "  " + name
+			if id == profiles.Profile.ID {
+				label = "● " + name
+			}
+
+			child, _ := submenu.AddChild(
+				tray.MenuItemLabel(label),
+				handler(func() {
+					if t.OnProfileSwitch != nil {
+						t.OnProfileSwitch(id)
+					}
+				}),
+			)
+			t.profileItems[id] = child
+		}
+		menu.AddChild(tray.MenuItemType(tray.Separator))
+	}
 
 	t.showItem, _ = menu.AddChild(tray.MenuItemLabel("Show"), handler(t.OnShow))
 	menu.AddChild(tray.MenuItemType(tray.Separator))
@@ -219,4 +256,34 @@ func exitToggleText(status *tsutil.IPNStatus) string {
 	}
 
 	return "Enable exit node"
+}
+
+// SetActiveProfile updates the profile indicator labels. It must be
+// called from a non-GTK goroutine to avoid deadlocking with D-Bus.
+func (t *Tray) SetActiveProfile(id ipn.ProfileID) {
+	if t == nil {
+		return
+	}
+
+	// Serialize indicator updates so concurrent callers cannot
+	// interleave their SetProps calls and end up with multiple items
+	// marked active.
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	for pid, item := range t.profileItems {
+		name := t.profileNames[pid]
+		label := "  " + name
+		if pid == id {
+			label = "● " + name
+		}
+		item.SetProps(tray.MenuItemLabel(label))
+	}
+}
+
+func profileName(profile ipn.LoginProfile) string {
+	if metadata.Private {
+		return "profile@example.com"
+	}
+	return profile.Name
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 	"github.com/inhies/go-bytesize"
 	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/ipn"
 	"tailscale.com/tailcfg"
 )
 
@@ -33,10 +34,11 @@ type App struct {
 	poller *tsutil.Poller
 	online bool
 
-	app      *adw.Application
-	win      *MainWindow
-	settings *gio.Settings
-	tray     *tray.Tray
+	app           *adw.Application
+	win           *MainWindow
+	settings      *gio.Settings
+	tray          *tray.Tray
+	activeProfile ipn.ProfileID
 
 	spinnum       int
 	operatorCheck bool
@@ -146,6 +148,11 @@ func (a *App) update(status tsutil.Status) {
 		}
 
 	case *tsutil.ProfileStatus:
+		if a.tray != nil && a.activeProfile != status.Profile.ID {
+			a.activeProfile = status.Profile.ID
+			go a.tray.SetActiveProfile(status.Profile.ID)
+		}
+
 		if a.win != nil {
 			a.win.Update(status)
 		}
@@ -358,7 +365,7 @@ func (a *App) onAppActivate(ctx context.Context) {
 
 func (a *App) initTray(ctx context.Context) {
 	if a.tray != nil {
-		err := a.tray.Start(<-a.poller.GetIPN())
+		err := a.tray.Start(<-a.poller.GetIPN(), nil)
 		if err != nil {
 			slog.Error("failed to start tray icon", "err", err)
 		}
@@ -428,12 +435,33 @@ func (a *App) initTray(ctx context.Context) {
 			})
 		},
 
+		OnProfileSwitch: func(id ipn.ProfileID) {
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+
+				err := tsutil.SwitchProfile(ctx, id)
+				if err != nil {
+					slog.Error("switch profile from tray", "err", err)
+					return
+				}
+
+				a.tray.SetActiveProfile(id)
+			}()
+		},
+
 		OnQuit: func() {
 			a.Quit()
 		},
 	}
 
-	err := a.tray.Start(<-a.poller.GetIPN())
+	var ps *tsutil.ProfileStatus
+	profile, profiles, err := tsutil.GetProfileStatus(ctx)
+	if err == nil {
+		ps = &tsutil.ProfileStatus{Profile: profile, Profiles: profiles}
+	}
+
+	err = a.tray.Start(<-a.poller.GetIPN(), ps)
 	if err != nil {
 		slog.Error("failed to start tray icon", "err", err)
 	}


### PR DESCRIPTION
## Summary

Adds a \"Switch account\" submenu to the system tray right-click menu, allowing the user to switch between Tailscale profiles without opening the main window. The currently active profile is shown with a bullet character (\`●\`) prefix, and the indicator updates whether the switch is initiated from the tray submenu or from the main window's profile dropdown.

Profiles are fetched once at tray startup via \`tsutil.GetProfileStatus\` and the submenu is populated in \`Tray.Start\`. The submenu only appears when there is more than one profile available.

## Dependency on tray library fix

This PR depends on **[DeedleFake/tray#2](https://github.com/DeedleFake/tray/pull/2)**, which fixes three bugs in \`deedles.dev/tray\` that were preventing this from working:

1. \`MenuItem.AddChild\` was calling \`emitPropertiesUpdated\` on the parent instead of the child, causing a nil pointer dereference and dropping the child's property notifications.
2. \`MenuItem.setChildren\` was mutating \`children-display\` without emitting it, so the desktop environment never learned that an item had become a submenu.
3. \`MenuItem.SetProps\` had a lock-order inversion with \`dbusmenu.GetLayout\` that caused a hard deadlock whenever \`SetProps\` was called concurrently with the DE fetching the menu layout.

While that PR is in flight, the trayscale \`go.mod\` has a temporary \`replace\` directive pointing at my fork at the relevant commit:

\`\`\`
replace deedles.dev/tray => github.com/alex-poor/tray v0.1.11-0.20260407004037-2451d98fc544
\`\`\`

Once the upstream tray PR is merged, the \`replace\` directive should be dropped and the regular \`deedles.dev/tray\` requirement updated to a new pseudo-version.

## Implementation notes

- The \"Switch account\" submenu must be the first item added to the menu — there is some interaction between the submenu's children and sibling items added to the root menu after it that I wasn't able to fully chase down. The trayscale code includes a comment explaining this constraint.
- \`SetActiveProfile\` updates the indicator labels using \`SetProps\`. It is called from a goroutine so that D-Bus emits don't run on the GTK main thread, and it serializes itself with \`Tray.m\` so concurrent indicator updates can't interleave and leave two items marked active.
- \`Tray.Start\` now takes an optional \`*tsutil.ProfileStatus\` so the submenu can be built in the same code path as all the other menu items, avoiding the need to mutate the menu after \`Start\` returns.

## Test plan

- [x] Tray menu shows \"Switch account\" submenu when more than one profile is configured
- [x] Tray menu does not show the submenu when only one profile is configured
- [x] Switching via the tray submenu actually switches profiles and the bullet indicator follows
- [x] Switching via the main window profile dropdown also updates the tray bullet indicator
- [x] No deadlocks or freezes during the disconnect/reconnect cycle that follows a profile switch
- [x] Respects \`TRAYSCALE_PRIVATE\` mode (profile names shown as \`profile@example.com\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)