### PR TITLE
internal/tsutil: preserve advertised routes when toggling exit node

### DIFF
--- a/internal/tsutil/client.go
+++ b/internal/tsutil/client.go
@@ -117,11 +117,14 @@ func SetUseExitNode(ctx context.Context, use bool) error {
 // AdvertiseExitNode enables and disables exit node advertisement for
 // the current node.
 func AdvertiseExitNode(ctx context.Context, enable bool) error {
-	var prefs ipn.Prefs
+	prefs, err := Prefs(ctx)
+	if err != nil {
+		return fmt.Errorf("get prefs: %w", err)
+	}
 	prefs.SetAdvertiseExitNode(enable)
 
-	_, err := localClient.EditPrefs(ctx, &ipn.MaskedPrefs{
-		Prefs:              prefs,
+	_, err = localClient.EditPrefs(ctx, &ipn.MaskedPrefs{
+		Prefs:              *prefs,
 		AdvertiseRoutesSet: true,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix `AdvertiseExitNode` to fetch current prefs before modifying, preserving existing advertised subnet routes when toggling the exit node switch
- Previously, a fresh empty `Prefs` struct was used, causing all advertised routes to be wiped on toggle

Fixes #257