### PR TITLE
internal/tsutil: add Auto-VPN to toggle Tailscale based on Wi-Fi network

### DIFF
--- a/dev.deedles.Trayscale.gschema.xml
+++ b/dev.deedles.Trayscale.gschema.xml
@@ -44,6 +44,24 @@
 				destination is configured.
 			</description>
 		</key>
+		<key name="auto-vpn-enabled" type="b">
+			<default>false</default>
+			<summary>Enable Auto-VPN</summary>
+			<description>
+				Automatically toggle the Tailscale VPN on or off based on the
+				current Wi-Fi network. When connected to a trusted network, VPN
+				is disabled. On untrusted or non-Wi-Fi networks, VPN is enabled.
+			</description>
+		</key>
+		<key name="auto-vpn-trusted-ssids" type="as">
+			<default>[]</default>
+			<summary>Trusted Wi-Fi SSIDs for Auto-VPN</summary>
+			<description>
+				A list of Wi-Fi network names (SSIDs) considered trusted. When
+				connected to one of these networks, Auto-VPN will disable the
+				Tailscale tunnel.
+			</description>
+		</key>
 	</schema>
 </schemalist>
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	deedles.dev/xiter v0.2.1
 	github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20260808200908-d4aecaa0ff32
 	github.com/diamondburned/gotk4/pkg v0.4.1
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/klauspost/compress v1.19.2
 	github.com/stretchr/testify v1.12.1
@@ -121,7 +122,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect

--- a/internal/tsutil/autowatcher.go
+++ b/internal/tsutil/autowatcher.go
@@ -1,0 +1,359 @@
+package tsutil
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+	"tailscale.com/ipn"
+)
+
+// AutoWatcher monitors Wi-Fi network changes via NetworkManager DBus
+// and automatically toggles the Tailscale VPN based on whether the
+// current SSID is in the trusted list.
+type AutoWatcher struct {
+	poller *Poller
+
+	mu         sync.Mutex
+	lastAction string // "enable", "disable", or ""
+	debounce   *time.Timer
+	conn       *dbus.Conn
+	cancel     context.CancelFunc
+
+	// Callbacks
+	OnSSIDChange func(ssid string)
+	OnVPNToggle  func(enabled bool, ssid string)
+
+	// Settings accessors (set by the UI layer)
+	IsEnabled   func() bool
+	TrustedList func() []string
+}
+
+// NewAutoWatcher creates a new AutoWatcher. The caller must set
+// IsEnabled, TrustedList, and optionally the callback fields before
+// calling Start.
+func NewAutoWatcher(poller *Poller) *AutoWatcher {
+	return &AutoWatcher{
+		poller: poller,
+	}
+}
+
+// Start begins watching for network changes. It blocks until the
+// context is cancelled or Stop is called.
+func (w *AutoWatcher) Start(ctx context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	w.mu.Lock()
+	w.cancel = cancel
+	w.mu.Unlock()
+
+	defer cancel()
+
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		slog.Error("auto-vpn: failed to connect to system DBus", "err", err)
+		return
+	}
+
+	// SSID detection requires NetworkManager. Without it there is
+	// nothing to watch, so bail out rather than sit in a loop that can
+	// only ever report an unknown network -- which the fail-secure path
+	// would treat as untrusted and force the VPN on.
+	if !nameHasOwner(conn, "org.freedesktop.NetworkManager") {
+		slog.Warn("auto-vpn: NetworkManager unavailable; auto-VPN disabled")
+		return
+	}
+	w.mu.Lock()
+	w.conn = conn
+	w.mu.Unlock()
+
+	// Subscribe to NetworkManager state changes
+	err = conn.AddMatchSignal(
+		dbus.WithMatchObjectPath("/org/freedesktop/NetworkManager"),
+		dbus.WithMatchInterface("org.freedesktop.NetworkManager"),
+		dbus.WithMatchMember("StateChanged"),
+	)
+	if err != nil {
+		slog.Error("auto-vpn: failed to subscribe to NM StateChanged", "err", err)
+	}
+
+	// Subscribe to property changes on NetworkManager
+	err = conn.AddMatchSignal(
+		dbus.WithMatchObjectPath("/org/freedesktop/NetworkManager"),
+		dbus.WithMatchInterface("org.freedesktop.DBus.Properties"),
+		dbus.WithMatchMember("PropertiesChanged"),
+	)
+	if err != nil {
+		slog.Error("auto-vpn: failed to subscribe to NM PropertiesChanged", "err", err)
+	}
+
+	signals := make(chan *dbus.Signal, 16)
+	conn.Signal(signals)
+
+	// Periodic re-evaluation to catch state changes (e.g. user manually
+	// connects Tailscale, or Tailscale state changes after initial eval)
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	// Initial evaluation
+	w.scheduleEvaluation(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-signals:
+			w.scheduleEvaluation(ctx)
+		case <-ticker.C:
+			w.scheduleEvaluation(ctx)
+		}
+	}
+}
+
+// Stop stops the watcher.
+func (w *AutoWatcher) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.cancel != nil {
+		w.cancel()
+		w.cancel = nil
+	}
+	if w.debounce != nil {
+		w.debounce.Stop()
+		w.debounce = nil
+	}
+	w.lastAction = ""
+}
+
+// Reevaluate resets dedup state and triggers an immediate evaluation.
+func (w *AutoWatcher) Reevaluate(ctx context.Context) {
+	w.mu.Lock()
+	w.lastAction = ""
+	w.mu.Unlock()
+
+	w.evaluateCurrent(ctx)
+}
+
+func (w *AutoWatcher) scheduleEvaluation(ctx context.Context) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.debounce != nil {
+		w.debounce.Stop()
+	}
+	w.debounce = time.AfterFunc(2*time.Second, func() {
+		w.evaluateCurrent(ctx)
+	})
+}
+
+func (w *AutoWatcher) evaluateCurrent(ctx context.Context) {
+	if w.IsEnabled == nil || !w.IsEnabled() {
+		return
+	}
+
+	ssid := w.CurrentSSID()
+	slog.Info("auto-vpn: evaluating network", "ssid", ssid)
+
+	if w.OnSSIDChange != nil {
+		w.OnSSIDChange(ssid)
+	}
+
+	if ssid != "" && w.isTrusted(ssid) {
+		w.disableVPN(ctx, ssid)
+	} else {
+		w.enableVPN(ctx, ssid)
+	}
+}
+
+func (w *AutoWatcher) isTrusted(ssid string) bool {
+	if w.TrustedList == nil {
+		return false
+	}
+	for _, s := range w.TrustedList() {
+		if s == ssid {
+			return true
+		}
+	}
+	return false
+}
+
+func (w *AutoWatcher) enableVPN(ctx context.Context, ssid string) {
+	// Check current state — if already running, just update tracking
+	status := <-w.poller.GetIPN()
+	if status.State == ipn.Running {
+		w.mu.Lock()
+		w.lastAction = "enable"
+		w.mu.Unlock()
+		return
+	}
+
+	// Dedup: only skip if we already tried to enable and VPN is still starting
+	w.mu.Lock()
+	if w.lastAction == "enable" {
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	slog.Info("auto-vpn: enabling VPN", "ssid", ssid)
+	err := Start(ctx)
+	if err != nil {
+		slog.Error("auto-vpn: failed to enable VPN", "err", err)
+		return
+	}
+
+	w.mu.Lock()
+	w.lastAction = "enable"
+	w.mu.Unlock()
+
+	if w.OnVPNToggle != nil {
+		w.OnVPNToggle(true, ssid)
+	}
+}
+
+func (w *AutoWatcher) disableVPN(ctx context.Context, ssid string) {
+	// Check current state — if already stopped, just update tracking
+	status := <-w.poller.GetIPN()
+	if status.State != ipn.Running {
+		w.mu.Lock()
+		w.lastAction = "disable"
+		w.mu.Unlock()
+		return
+	}
+
+	// Dedup: only skip if we already tried to disable and VPN is still stopping
+	w.mu.Lock()
+	if w.lastAction == "disable" {
+		w.mu.Unlock()
+		return
+	}
+	w.mu.Unlock()
+
+	slog.Info("auto-vpn: disabling VPN", "ssid", ssid)
+	err := Stop(ctx)
+	if err != nil {
+		slog.Error("auto-vpn: failed to disable VPN", "err", err)
+		return
+	}
+
+	w.mu.Lock()
+	w.lastAction = "disable"
+	w.mu.Unlock()
+
+	if w.OnVPNToggle != nil {
+		w.OnVPNToggle(false, ssid)
+	}
+}
+
+// CurrentSSID returns the SSID of the currently connected Wi-Fi
+// network. Returns empty string if not connected to Wi-Fi or if
+// detection fails.
+func (w *AutoWatcher) CurrentSSID() string {
+	return w.currentSSIDDBus()
+}
+
+// DetectCurrentSSID returns the current Wi-Fi SSID without requiring
+// an AutoWatcher instance. Used by the preferences UI.
+func DetectCurrentSSID() string {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return ""
+	}
+	return detectSSIDViaDBus(conn)
+}
+
+func (w *AutoWatcher) currentSSIDDBus() string {
+	w.mu.Lock()
+	conn := w.conn
+	w.mu.Unlock()
+
+	if conn == nil {
+		var err error
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return ""
+		}
+	}
+
+	return detectSSIDViaDBus(conn)
+}
+
+// NetworkManagerAvailable reports whether NetworkManager is present on
+// the system bus. Auto-VPN needs it to resolve the current Wi-Fi SSID;
+// there is no portable alternative, since neither gio.NetworkMonitor nor
+// the NetworkMonitor portal expose SSID information. When this returns
+// false the UI disables the Auto-VPN controls and explains why.
+func NetworkManagerAvailable() bool {
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		slog.Debug("auto-vpn: no system bus", "err", err)
+		return false
+	}
+	return nameHasOwner(conn, "org.freedesktop.NetworkManager")
+}
+
+// nameHasOwner asks the bus daemon whether name is currently owned,
+// which avoids activating the service just to probe for it.
+func nameHasOwner(conn *dbus.Conn, name string) bool {
+	bus := conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus")
+
+	var owned bool
+	err := bus.Call("org.freedesktop.DBus.NameHasOwner", 0, name).Store(&owned)
+	if err != nil {
+		slog.Debug("auto-vpn: NameHasOwner failed", "name", name, "err", err)
+		return false
+	}
+	return owned
+}
+
+func detectSSIDViaDBus(conn *dbus.Conn) string {
+	nm := conn.Object("org.freedesktop.NetworkManager", "/org/freedesktop/NetworkManager")
+
+	// Get list of devices
+	var devicePaths []dbus.ObjectPath
+	err := nm.Call("org.freedesktop.NetworkManager.GetDevices", 0).Store(&devicePaths)
+	if err != nil {
+		slog.Debug("auto-vpn: failed to get NM devices", "err", err)
+		return ""
+	}
+
+	for _, devPath := range devicePaths {
+		dev := conn.Object("org.freedesktop.NetworkManager", devPath)
+
+		// Check device type (2 = Wi-Fi)
+		deviceType, err := dev.GetProperty("org.freedesktop.NetworkManager.Device.DeviceType")
+		if err != nil {
+			continue
+		}
+		if deviceType.Value().(uint32) != 2 {
+			continue
+		}
+
+		// Get active access point
+		apPathVariant, err := dev.GetProperty("org.freedesktop.NetworkManager.Device.Wireless.ActiveAccessPoint")
+		if err != nil {
+			continue
+		}
+		apPath, ok := apPathVariant.Value().(dbus.ObjectPath)
+		if !ok || apPath == "/" || apPath == "" {
+			continue
+		}
+
+		// Get SSID from access point
+		ap := conn.Object("org.freedesktop.NetworkManager", apPath)
+		ssidVariant, err := ap.GetProperty("org.freedesktop.NetworkManager.AccessPoint.Ssid")
+		if err != nil {
+			continue
+		}
+		ssidBytes, ok := ssidVariant.Value().([]byte)
+		if !ok || len(ssidBytes) == 0 {
+			continue
+		}
+
+		return string(ssidBytes)
+	}
+
+	return ""
+}

--- a/internal/tsutil/autowatcher.go
+++ b/internal/tsutil/autowatcher.go
@@ -17,7 +17,8 @@ type AutoWatcher struct {
 	poller *Poller
 
 	mu         sync.Mutex
-	lastAction string // "enable", "disable", or ""
+	evalMu     sync.Mutex // serialises whole evaluations; never held with mu
+	lastAction string     // "enable", "disable", or ""
 	debounce   *time.Timer
 	conn       *dbus.Conn
 	cancel     context.CancelFunc
@@ -153,6 +154,18 @@ func (w *AutoWatcher) evaluateCurrent(ctx context.Context) {
 		return
 	}
 
+	// One evaluation at a time. Settings changes, the debounce timer and
+	// the ticker can all land at once; without this each could pass the
+	// dedup check while another is blocked reading the poller and issue a
+	// duplicate Start/Stop.
+	w.evalMu.Lock()
+	defer w.evalMu.Unlock()
+
+	// Stop may have been called while waiting for the lock.
+	if ctx.Err() != nil {
+		return
+	}
+
 	ssid := w.CurrentSSID()
 	slog.Info("auto-vpn: evaluating network", "ssid", ssid)
 
@@ -164,6 +177,18 @@ func (w *AutoWatcher) evaluateCurrent(ctx context.Context) {
 		w.disableVPN(ctx, ssid)
 	} else {
 		w.enableVPN(ctx, ssid)
+	}
+}
+
+// ipnState reads the current IPN status, giving up if the watcher is
+// stopped first. The poller channel may never deliver, and a plain
+// receive would leave Stop() unable to unblock the evaluation.
+func (w *AutoWatcher) ipnState(ctx context.Context) (*IPNStatus, bool) {
+	select {
+	case status := <-w.poller.GetIPN():
+		return status, true
+	case <-ctx.Done():
+		return nil, false
 	}
 }
 
@@ -181,7 +206,10 @@ func (w *AutoWatcher) isTrusted(ssid string) bool {
 
 func (w *AutoWatcher) enableVPN(ctx context.Context, ssid string) {
 	// Check current state — if already running, just update tracking
-	status := <-w.poller.GetIPN()
+	status, ok := w.ipnState(ctx)
+	if !ok {
+		return
+	}
 	if status.State == ipn.Running {
 		w.mu.Lock()
 		w.lastAction = "enable"
@@ -199,6 +227,10 @@ func (w *AutoWatcher) enableVPN(ctx context.Context, ssid string) {
 
 	slog.Info("auto-vpn: enabling VPN", "ssid", ssid)
 	err := Start(ctx)
+	if ctx.Err() != nil {
+		// Stopped mid-flight; do not report state the app no longer tracks.
+		return
+	}
 	if err != nil {
 		slog.Error("auto-vpn: failed to enable VPN", "err", err)
 		return
@@ -215,7 +247,10 @@ func (w *AutoWatcher) enableVPN(ctx context.Context, ssid string) {
 
 func (w *AutoWatcher) disableVPN(ctx context.Context, ssid string) {
 	// Check current state — if already stopped, just update tracking
-	status := <-w.poller.GetIPN()
+	status, ok := w.ipnState(ctx)
+	if !ok {
+		return
+	}
 	if status.State != ipn.Running {
 		w.mu.Lock()
 		w.lastAction = "disable"
@@ -233,6 +268,10 @@ func (w *AutoWatcher) disableVPN(ctx context.Context, ssid string) {
 
 	slog.Info("auto-vpn: disabling VPN", "ssid", ssid)
 	err := Stop(ctx)
+	if ctx.Err() != nil {
+		// Stopped mid-flight; do not report state the app no longer tracks.
+		return
+	}
 	if err != nil {
 		slog.Error("auto-vpn: failed to disable VPN", "err", err)
 		return

--- a/internal/tsutil/autowatcher_test.go
+++ b/internal/tsutil/autowatcher_test.go
@@ -1,0 +1,119 @@
+package tsutil
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Concurrent evaluations must not overlap. Before the evalMu fix, callers
+// could interleave inside evaluateCurrent while another was blocked reading
+// the poller, letting both pass the dedup check and both act.
+//
+// A real Poller with nothing feeding it gives a genuinely blocking GetIPN(),
+// which is the window the old code raced in.
+func TestEvaluateCurrentIsSerialised(t *testing.T) {
+	var inFlight, maxInFlight, entered int32
+
+	w := &AutoWatcher{poller: &Poller{}}
+	w.IsEnabled = func() bool { return true }
+	w.TrustedList = func() []string { return nil }
+	w.OnSSIDChange = func(string) {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			old := atomic.LoadInt32(&maxInFlight)
+			if n <= old || atomic.CompareAndSwapInt32(&maxInFlight, old, n) {
+				break
+			}
+		}
+		atomic.AddInt32(&entered, 1)
+		time.Sleep(30 * time.Millisecond) // widen the race window
+		atomic.AddInt32(&inFlight, -1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			w.evaluateCurrent(ctx)
+		}()
+	}
+
+	// Let one evaluation take evalMu and park on the poller read, then
+	// cancel so every goroutine can unwind.
+	time.Sleep(300 * time.Millisecond)
+	cancel()
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxInFlight); got > 1 {
+		t.Errorf("evaluations overlapped: max concurrent = %d, want 1", got)
+	}
+	if atomic.LoadInt32(&entered) == 0 {
+		t.Fatal("no evaluation ran; test proved nothing")
+	}
+	t.Logf("entered=%d maxConcurrent=%d", atomic.LoadInt32(&entered), atomic.LoadInt32(&maxInFlight))
+}
+
+// A stopped watcher must not keep firing callbacks into UI code the app has
+// already torn down.
+func TestNoCallbacksAfterStop(t *testing.T) {
+	var after int32
+
+	w := &AutoWatcher{poller: &Poller{}}
+	w.IsEnabled = func() bool { return true }
+	w.TrustedList = func() []string { return nil }
+	w.OnSSIDChange = func(string) { atomic.AddInt32(&after, 1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.cancel = cancel
+
+	w.Stop()
+
+	for i := 0; i < 20; i++ {
+		w.evaluateCurrent(ctx)
+	}
+
+	if got := atomic.LoadInt32(&after); got != 0 {
+		t.Errorf("got %d callbacks after Stop(), want 0", got)
+	}
+	t.Logf("callbacks after Stop = %d", atomic.LoadInt32(&after))
+}
+
+// Stop() must not block behind an evaluation that is holding evalMu.
+func TestStopDoesNotDeadlock(t *testing.T) {
+	w := &AutoWatcher{poller: &Poller{}}
+	w.IsEnabled = func() bool { return true }
+	w.TrustedList = func() []string { return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.cancel = cancel
+
+	entered := make(chan struct{})
+	var once sync.Once
+	w.OnSSIDChange = func(string) { once.Do(func() { close(entered) }) }
+
+	go w.evaluateCurrent(ctx) // parks on the poller read holding evalMu
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("evaluation never started")
+	}
+
+	done := make(chan struct{})
+	go func() { w.Stop(); close(done) }()
+
+	select {
+	case <-done:
+		t.Log("Stop() returned while an evaluation held evalMu")
+	case <-time.After(3 * time.Second):
+		t.Fatal("Stop() deadlocked behind a running evaluation")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -46,6 +46,7 @@ type App struct {
 	autoSaving     sync.Map // waiting-file name -> struct{} while save is in flight
 	autoSaveFailed sync.Map // waiting-file name -> struct{} after a failed auto-save attempt
 	autoSaveDirBad string   // destination dir last logged as unusable; avoids log spam
+	autoWatcher    *tsutil.AutoWatcher
 }
 
 func (a *App) clip(v *glib.Value) {
@@ -475,8 +476,49 @@ func (a *App) initTray(ctx context.Context) {
 	}
 }
 
+func (a *App) startAutoWatcher(ctx context.Context) {
+	if a.autoWatcher != nil {
+		a.autoWatcher.Stop()
+	}
+
+	a.autoWatcher = tsutil.NewAutoWatcher(a.poller)
+	a.autoWatcher.IsEnabled = func() bool {
+		if a.settings == nil {
+			return false
+		}
+		return a.settings.Boolean("auto-vpn-enabled")
+	}
+	a.autoWatcher.TrustedList = func() []string {
+		if a.settings == nil {
+			return nil
+		}
+		return a.settings.Strv("auto-vpn-trusted-ssids")
+	}
+	a.autoWatcher.OnVPNToggle = func(enabled bool, ssid string) {
+		if enabled {
+			if ssid != "" {
+				a.notify("Auto-VPN", fmt.Sprintf("Connected (untrusted network: %s)", ssid))
+			} else {
+				a.notify("Auto-VPN", "Connected (no Wi-Fi detected)")
+			}
+		} else {
+			a.notify("Auto-VPN", fmt.Sprintf("Disconnected (trusted network: %s)", ssid))
+		}
+	}
+
+	go a.autoWatcher.Start(ctx)
+}
+
+func (a *App) stopAutoWatcher() {
+	if a.autoWatcher != nil {
+		a.autoWatcher.Stop()
+		a.autoWatcher = nil
+	}
+}
+
 // Quit exits the app completely, causing Run to return.
 func (a *App) Quit() {
+	a.stopAutoWatcher()
 	a.tray.Close()
 	a.app.Quit()
 }
@@ -502,6 +544,11 @@ func (a *App) Run(ctx context.Context) {
 		New:      func(s tsutil.Status) { glib.IdleAdd(func() { a.update(s) }) },
 	}
 	go a.poller.Run(ctx)
+
+	// Start Auto-VPN watcher if enabled
+	if a.settings != nil && a.settings.Boolean("auto-vpn-enabled") {
+		a.startAutoWatcher(ctx)
+	}
 
 	a.app.Run(os.Args)
 }

--- a/internal/ui/preferences.go
+++ b/internal/ui/preferences.go
@@ -2,9 +2,12 @@ package ui
 
 import (
 	_ "embed"
+	"slices"
 
 	"deedles.dev/trayscale/internal/gutil"
+	"deedles.dev/trayscale/internal/tsutil"
 	"github.com/diamondburned/gotk4-adwaita/pkg/adw"
+	"github.com/diamondburned/gotk4/pkg/gio/v2"
 	"github.com/diamondburned/gotk4/pkg/gtk/v4"
 )
 
@@ -18,10 +21,140 @@ type PreferencesDialog struct {
 	PollingIntervalAdjustment    *gtk.Adjustment
 	TaildropAutoSaveRow          *adw.SwitchRow
 	TaildropAutoSaveFolderButton *gtk.Button
+
+	// Auto-VPN
+	AutoVpnGroup             *adw.PreferencesGroup
+	AutoVpnEnabledRow        *adw.SwitchRow
+	AutoVpnCurrentNetworkRow *adw.ActionRow
+
+	// tracked trusted SSID rows for removal
+	trustedRows map[string]*adw.ActionRow
 }
 
 func NewPreferencesDialog() *PreferencesDialog {
 	var win PreferencesDialog
 	gutil.FillFromUI(&win, preferencesXML)
+	win.trustedRows = make(map[string]*adw.ActionRow)
 	return &win
+}
+
+func (d *PreferencesDialog) addTrustedRow(a *App, ssid string) {
+	if _, exists := d.trustedRows[ssid]; exists {
+		return
+	}
+
+	row := adw.NewActionRow()
+	row.SetTitle(ssid)
+	row.SetIconName("network-wireless-symbolic")
+
+	removeBtn := gtk.NewButtonFromIconName("user-trash-symbolic")
+	removeBtn.SetVAlign(gtk.AlignCenter)
+	removeBtn.AddCSSClass("flat")
+	removeBtn.SetTooltipText("Remove")
+	removeBtn.ConnectClicked(func() {
+		current := a.settings.Strv("auto-vpn-trusted-ssids")
+		current = slices.DeleteFunc(current, func(v string) bool { return v == ssid })
+		a.settings.SetStrv("auto-vpn-trusted-ssids", current)
+		d.removeTrustedRow(ssid)
+	})
+	row.AddSuffix(removeBtn)
+
+	d.trustedRows[ssid] = row
+	d.AutoVpnGroup.Add(row)
+}
+
+func (d *PreferencesDialog) removeTrustedRow(ssid string) {
+	if row, exists := d.trustedRows[ssid]; exists {
+		d.AutoVpnGroup.Remove(row)
+		delete(d.trustedRows, ssid)
+	}
+}
+
+// setupAutoVPN wires up the Auto-VPN UI elements.
+func (d *PreferencesDialog) setupAutoVPN(a *App) {
+	if a.settings == nil {
+		return
+	}
+
+	// Auto-VPN resolves the current Wi-Fi SSID through NetworkManager.
+	// There is no portable alternative -- neither gio.NetworkMonitor nor
+	// the NetworkMonitor portal expose SSIDs -- so without it the feature
+	// cannot work. Disable the controls and say why rather than offering
+	// settings that would silently do nothing.
+	if !tsutil.NetworkManagerAvailable() {
+		d.AutoVpnGroup.SetSensitive(false)
+		d.AutoVpnGroup.SetDescription("Unavailable: Auto-VPN needs NetworkManager to identify the current Wi-Fi network.")
+		d.AutoVpnCurrentNetworkRow.SetSubtitle("NetworkManager not available")
+		return
+	}
+
+	ssid := tsutil.DetectCurrentSSID()
+
+	trustedSSIDs := a.settings.Strv("auto-vpn-trusted-ssids")
+	isTrusted := slices.Contains(trustedSSIDs, ssid)
+
+	if ssid != "" {
+		d.AutoVpnCurrentNetworkRow.SetSubtitle(ssid)
+
+		trustBtn := gtk.NewButton()
+		if isTrusted {
+			trustBtn.SetLabel("Untrust")
+			trustBtn.AddCSSClass("destructive-action")
+		} else {
+			trustBtn.SetLabel("Trust")
+			trustBtn.AddCSSClass("suggested-action")
+		}
+		trustBtn.SetVAlign(gtk.AlignCenter)
+		trustBtn.ConnectClicked(func() {
+			current := a.settings.Strv("auto-vpn-trusted-ssids")
+			if slices.Contains(current, ssid) {
+				current = slices.DeleteFunc(current, func(s string) bool { return s == ssid })
+				trustBtn.SetLabel("Trust")
+				trustBtn.RemoveCSSClass("destructive-action")
+				trustBtn.AddCSSClass("suggested-action")
+				d.removeTrustedRow(ssid)
+			} else {
+				current = append(current, ssid)
+				trustBtn.SetLabel("Untrust")
+				trustBtn.RemoveCSSClass("suggested-action")
+				trustBtn.AddCSSClass("destructive-action")
+				d.addTrustedRow(a, ssid)
+			}
+			a.settings.SetStrv("auto-vpn-trusted-ssids", current)
+		})
+		d.AutoVpnCurrentNetworkRow.AddSuffix(trustBtn)
+	} else {
+		d.AutoVpnCurrentNetworkRow.SetSubtitle("Not connected to Wi-Fi")
+	}
+
+	// Manual SSID entry row
+	entryRow := adw.NewEntryRow()
+	entryRow.SetTitle("Add trusted SSID")
+	entryRow.ConnectApply(func() {
+		text := entryRow.Text()
+		if text == "" {
+			return
+		}
+		current := a.settings.Strv("auto-vpn-trusted-ssids")
+		if !slices.Contains(current, text) {
+			current = append(current, text)
+			a.settings.SetStrv("auto-vpn-trusted-ssids", current)
+			d.addTrustedRow(a, text)
+		}
+		entryRow.SetText("")
+	})
+	entryRow.SetShowApplyButton(true)
+	d.AutoVpnGroup.Add(entryRow)
+
+	// Build initial trusted SSID list
+	for _, s := range trustedSSIDs {
+		d.addTrustedRow(a, s)
+	}
+}
+
+// addAutoVPNActions sets up the settings bindings and callbacks for
+// the Auto-VPN preferences UI.
+func (d *PreferencesDialog) addAutoVPNActions(a *App, settings *gio.Settings) {
+	settings.Bind("auto-vpn-enabled", d.AutoVpnEnabledRow.Object, "active", gio.SettingsBindDefault)
+	d.setupAutoVPN(a)
 }

--- a/internal/ui/preferences.go
+++ b/internal/ui/preferences.go
@@ -45,7 +45,7 @@ func (d *PreferencesDialog) addTrustedRow(a *App, ssid string) {
 
 	row := adw.NewActionRow()
 	row.SetTitle(ssid)
-	row.SetIconName("network-wireless-symbolic")
+	row.AddPrefix(gtk.NewImageFromIconName("network-wireless-symbolic"))
 
 	removeBtn := gtk.NewButtonFromIconName("user-trash-symbolic")
 	removeBtn.SetVAlign(gtk.AlignCenter)

--- a/internal/ui/preferences.ui
+++ b/internal/ui/preferences.ui
@@ -52,6 +52,24 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="AdwPreferencesGroup" id="AutoVpnGroup">
+            <property name="title">Auto-VPN</property>
+            <property name="description">Automatically toggle VPN based on Wi-Fi network</property>
+            <child>
+              <object class="AdwSwitchRow" id="AutoVpnEnabledRow">
+                <property name="title">Enable Auto-VPN</property>
+                <property name="subtitle">Disable VPN on trusted Wi-Fi, enable on untrusted</property>
+              </object>
+            </child>
+            <child>
+              <object class="AdwActionRow" id="AutoVpnCurrentNetworkRow">
+                <property name="title">Current Network</property>
+                <property name="subtitle">Detecting...</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </object>

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -56,6 +56,18 @@ func (a *App) initSettings(ctx context.Context) {
 					a.win.SetShowOffline(a.settings.Boolean("show-offline-peers"))
 				}
 			})
+
+		case "auto-vpn-enabled":
+			if a.settings.Boolean("auto-vpn-enabled") {
+				a.startAutoWatcher(ctx)
+			} else {
+				a.stopAutoWatcher()
+			}
+
+		case "auto-vpn-trusted-ssids":
+			if a.autoWatcher != nil {
+				go a.autoWatcher.Reevaluate(ctx)
+			}
 		}
 	})
 
@@ -171,6 +183,7 @@ func (a *App) showPreferences() {
 		})
 	})
 
+	dialog.addAutoVPNActions(a, a.settings)
 	dialog.PreferencesDialog.Present(a.window())
 }
 


### PR DESCRIPTION
This is the Auto-VPN thing from #278, finally. Sorry it took so long to turn up.

Short version: it turns Tailscale off on Wi-Fi networks you've marked trusted and back on everywhere else — untrusted Wi-Fi, wired, no network at all, or an SSID it can't read. Off by default.

I built it to what we agreed in that thread rather than what I first proposed, so: NetworkManager only, no iwd backend, no gio.NetworkMonitor swap. If NM isn't on the bus the whole preferences group goes insensitive with a line explaining why, and the watcher just returns rather than spinning. The `iwgetid` fallback is gone too — you were right that it was never going to work inside the Flatpak. Settings are two GSettings keys in the existing preferences dialog.

Couple of things in #278 that are stale now: no iwgetid, and autowatcher.go came out around 400 lines rather than the ~315 I guessed, mostly the NM-availability handling and the concurrency stuff below.

You asked:

> Just to be clear, this simply turns Tailscale on and off, not the exit node, right? Because that just doesn't seem that useful to me.

Yeah, on/off — same `tsutil.Start()`/`Stop()` path as the tray toggle.

The case I built it for is a laptop that moves around. At home I want the NAS and the printer on the plain LAN without going through the tunnel; on hotel or conference wifi I want it up and I don't want to have to remember. So it's peer-to-peer access being toggled, not exit node routing. I get that if you're mostly stationary this is less compelling.

An exit-node version would drop into the same machinery though — the trusted list and the watcher are unchanged, only the action differs. Say the word and I'll add it here or as a follow-up, whichever you prefer.

Mechanically it watches NetworkManager's StateChanged and PropertiesChanged, pulls the SSID off the active AP over DBus, checks it against the list. Network events get a 2s debounce so roaming doesn't thrash it, plus a 10s ticker for anything that changes without a signal. It checks actual VPN state before doing anything, so a settled state doesn't generate repeated calls. Anything it can't identify counts as untrusted and the tunnel comes up — I'd rather it be on when it shouldn't be than off when it should.

The concurrency was where the actual bugs were, so worth flagging. Settings changes, the debounce timer and the ticker can all land at once, and the original code checked its dedup state, dropped the lock, blocked on the poller, then acted — so two of them could both decide to act on the same transition. Evaluations are now serialised under their own mutex, and it's deliberately never held while taking the other one so Stop() can't wedge behind a running evaluation.

Two things fell out of that. `GetIPN()` hands back an unbuffered channel, so anything parked on it couldn't be released by Stop() at all — that read selects on the context now. And an evaluation already in flight would happily call back into UI state after teardown, so the context gets checked after the lock and again after Start/Stop returns.

There are tests for all three in autowatcher_test.go. I checked they actually fail against the old code rather than just passing — without the evaluation lock you get eight overlapping evaluations instead of one.

Testing was on Ubuntu 26.04.1, GTK 4.22.4 / libadwaita 1.9.1, Go 1.27, tailscaled 1.102.3. SSID detection matches what nmcli reports. Trusting the current network takes it Running -> Stopped, untrusting brings it back, and I confirmed both against tailscaled's own log rather than just the UI. I also sat there flapping trust/untrust every two or three seconds to try and provoke it: exactly one EditPrefs per action, no oscillation, and the ticker stays quiet once things settle. Empty and nil trusted lists are inert, as is a disabled watcher. build/vet/staticcheck are clean — staticcheck reports the same two pre-existing poller.go findings as master and nothing else. `go test -race` is clean.

One gap I should mention: I haven't actually exercised the debounce. Settings changes go through Reevaluate and skip it by design, so testing it properly needs a real network transition rather than clicking things in the UI.

For Flatpak it needs one permission in the flathub manifest, which I'll send separately if this lands:

```yaml
  - --system-talk-name=org.freedesktop.NetworkManager
```

Without it you get the NM-unavailable path rather than anything broken.

Last thing, unrelated to this branch but relevant if you go to test it: master currently segfaults on startup against a 1.102.x daemon, which I wrote up in #290. I had that library bump applied locally while testing this; it's deliberately not in this PR.
