### PR TITLE
internal/ui, internal/gutil, internal/tsutil: drop unused fields and helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module deedles.dev/trayscale
 go 1.27.0
 
 require (
-	deedles.dev/mk v0.1.0
 	deedles.dev/tray v0.1.11-0.20260216023918-8e44c43dfc0b
 	deedles.dev/xiter v0.2.1
 	github.com/diamondburned/gotk4-adwaita/pkg v0.0.0-20260808200908-d4aecaa0ff32

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ codeberg.org/chavacava/garif v0.2.0 h1:F0tVjhYbuOCnvNcU3YSpO6b3Waw6Bimy4K0mM8y6M
 codeberg.org/chavacava/garif v0.2.0/go.mod h1:P2BPbVbT4QcvLZrORc2T29szK3xEOlnl0GiPTJmEqBQ=
 codeberg.org/polyfloyd/go-errorlint v1.9.0 h1:VkdEEmA1VBpH6ecQoMR4LdphVI3fA4RrCh2an7YmodI=
 codeberg.org/polyfloyd/go-errorlint v1.9.0/go.mod h1:GPRRu2LzVijNn4YkrZYJfatQIdS+TrcK8rL5Xs24qw8=
-deedles.dev/mk v0.1.0 h1:xrvuJA3+R/j6/6AZPc+o31I1rotdKLrAYJxhZJwdOuc=
-deedles.dev/mk v0.1.0/go.mod h1:TSFsz0T+BvhNqJae0yrj+KadkN4elx248PCpq2Ol4ME=
 deedles.dev/tray v0.1.11-0.20260216023918-8e44c43dfc0b h1:enjE1KUvBCJeeYJIfuSpb8yqF8V51JqTikv4zfRo0xY=
 deedles.dev/tray v0.1.11-0.20260216023918-8e44c43dfc0b/go.mod h1:T6LSCKPLN2Y+PfawRiZOq3awibqxBm4RCmYrDQgMf04=
 deedles.dev/xiter v0.2.1 h1:yyyfo1sDwARp5lyMvILBJpEI28sIFN0TNYagAdBUa+s=

--- a/internal/gutil/gutil.go
+++ b/internal/gutil/gutil.go
@@ -148,27 +148,6 @@ func PointerToWidgetter[T any, P interface {
 	return p
 }
 
-// Classy wraps the CSS-related methods of a gtk.Widget.
-type Classy interface {
-	AddCSSClass(string)
-	RemoveCSSClass(string)
-	HasCSSClass(string) bool
-	CSSClasses() []string
-}
-
-// SetCSSClass adds or removes a CSS class based on a boolean
-// argument.
-func SetCSSClass(w Classy, class string, force bool) {
-	if force {
-		w.AddCSSClass(class)
-		return
-	}
-
-	if !force {
-		w.RemoveCSSClass(class)
-	}
-}
-
 // Caster wraps the [glib.Object.Cast] method.
 type Caster interface {
 	Cast() glib.Objector

--- a/internal/tsutil/poller.go
+++ b/internal/tsutil/poller.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"deedles.dev/mk"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/feature/taildrop"
 	"tailscale.com/ipn"
@@ -48,10 +47,10 @@ type Poller struct {
 
 func (p *Poller) init() {
 	p.once.Do(func() {
-		mk.Chan(&p.poll, 0)
-		mk.Chan(&p.getIPN, 0)
-		mk.Chan(&p.nextIPN, 0)
-		mk.Chan(&p.interval, 0)
+		p.poll = make(chan struct{})
+		p.getIPN = make(chan *IPNStatus)
+		p.nextIPN = make(chan *IPNStatus)
+		p.interval = make(chan time.Duration)
 	})
 }
 
@@ -299,7 +298,7 @@ func (s IPNStatus) copy() *IPNStatus {
 
 func (s *IPNStatus) ensurePeers() {
 	if s.Peers == nil {
-		mk.Map(&s.Peers, 0)
+		s.Peers = make(map[tailcfg.StableNodeID]tailcfg.NodeView)
 	}
 }
 

--- a/internal/tsutil/tsutil.go
+++ b/internal/tsutil/tsutil.go
@@ -3,7 +3,6 @@ package tsutil
 import (
 	"cmp"
 
-	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
 )
 
@@ -56,14 +55,5 @@ func ComparePeers(p1, p2 tailcfg.NodeView) int {
 		loc,
 		cmp.Compare(i1.Hostname(), i2.Hostname()),
 		cmp.Compare(p1.ID(), p2.ID()),
-	)
-}
-
-// CompareWaitingFiles compares two incoming files first by name and
-// then by size.
-func CompareWaitingFiles(f1, f2 apitype.WaitingFile) int {
-	return cmp.Or(
-		cmp.Compare(f1.Name, f2.Name),
-		cmp.Compare(f1.Size, f2.Size),
 	)
 }

--- a/internal/ui/dialogs.go
+++ b/internal/ui/dialogs.go
@@ -109,10 +109,9 @@ func (d Info) Show(a *App, closed func()) {
 }
 
 type Select[T any] struct {
-	Heading  string
-	Body     string
-	Options  []SelectOption[T]
-	Multiple bool
+	Heading string
+	Body    string
+	Options []SelectOption[T]
 }
 
 type SelectOption[T any] struct {
@@ -125,10 +124,6 @@ func (d Select[T]) Show(a *App, res func([]SelectOption[T])) {
 	options := gtk.NewListBox()
 	options.AddCSSClass("boxed-list")
 	options.SetSelectionMode(gtk.SelectionSingle)
-	if d.Multiple {
-		// BUG: See https://gitlab.gnome.org/GNOME/gtk/-/issues/552.
-		options.SetSelectionMode(gtk.SelectionMultiple)
-	}
 	for _, option := range d.Options {
 		row := adw.NewActionRow()
 		row.SetTitle(option.Title)

--- a/internal/ui/peerpage.go
+++ b/internal/ui/peerpage.go
@@ -37,25 +37,6 @@ type PeerPage struct {
 	IPList                *gtk.ListBox
 	AdvertisedRoutesGroup *adw.PreferencesGroup
 	AdvertisedRoutesList  *gtk.ListBox
-	UDPRow                *adw.ActionRow
-	UDP                   *gtk.Image
-	IPv4Row               *adw.ActionRow
-	IPv4Icon              *gtk.Image
-	IPv4Addr              *gtk.Label
-	IPv6Row               *adw.ActionRow
-	IPv6Icon              *gtk.Image
-	IPv6Addr              *gtk.Label
-	UPnPRow               *adw.ActionRow
-	UPnP                  *gtk.Image
-	PMPRow                *adw.ActionRow
-	PMP                   *gtk.Image
-	PCPRow                *adw.ActionRow
-	PCP                   *gtk.Image
-	HairPinningRow        *adw.ActionRow
-	HairPinning           *gtk.Image
-	PreferredDERPRow      *adw.ActionRow
-	PreferredDERP         *gtk.Label
-	DERPLatencies         *adw.ExpanderRow
 	MiscGroup             *adw.PreferencesGroup
 	ExitNodeRow           *adw.SwitchRow
 	OnlineRow             *adw.ActionRow
@@ -70,8 +51,6 @@ type PeerPage struct {
 	RxBytes               *gtk.Label
 	TxBytesRow            *adw.ActionRow
 	TxBytes               *gtk.Label
-	SendFileBurron        *adw.ButtonRow
-	SendDirButton         *adw.ButtonRow
 	DropTarget            *gtk.DropTarget
 
 	sendFileAction *gio.SimpleAction


### PR DESCRIPTION
Opened by Coder (Grok Bot), not typed by DeedleFake.

Drop unused GTK fields and helpers. Deslop only; no other cleanup.

1. **internal/ui/peerpage.go** — Drop leftover `FillFromUI` struct fields that are not in `peerpage.ui` and are never read: SelfPage/netcheck widgets (`UDPRow`/`UDP`, `IPv4*`, `IPv6*`, `UPnP*`, `PMP*`, `PCP*`, `HairPinningRow`/`HairPinning`, `PreferredDERPRow`/`PreferredDERP`, `DERPLatencies`) and old send-file widgets (`SendFileBurron`, `SendDirButton`). Netcheck widgets remain on `selfpage.ui`. Advertised Routes is untouched.

2. **internal/gutil/gutil.go** — Delete unused `Classy` and `SetCSSClass` (zero callers). `AddCSSClass` continues to be used directly in `dialogs.go` / `app.go`.

3. **internal/tsutil/tsutil.go** — Delete unused `CompareWaitingFiles`. Not wired into `waitingFileSorter`; the sorter in `internal/ui/ui.go` already inlines the same name-then-size cmp. No tests existed for it.

4. **internal/ui/dialogs.go** — Remove `Select.Multiple` and the multi-select GTK #552 workaround. The only caller (`Select[tailcfg.NodeView]` in `onAppOpen`) never set `Multiple`. `Select` is now single-select only. No tests mentioned `Multiple`.

5. **internal/tsutil/poller.go** — Replace `mk.Chan`/`mk.Map` with `make()` for poll/getIPN/nextIPN/interval channels and the Peers map. Drop `deedles.dev/mk` from `go.mod`/`go.sum`. Confirmed no other file imported it.

Nothing listed was skipped; all five items were still present and unused.
